### PR TITLE
[codex] Implement Mac app foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  swift-package:
+    name: Swift Package
+    runs-on: macos-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Show Swift version
+        run: swift --version
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+    name: "Toki",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .library(name: "TokiCore", targets: ["TokiCore"]),
+        .executable(name: "TokiApp", targets: ["TokiApp"])
+    ],
+    targets: [
+        .target(name: "TokiCore"),
+        .executableTarget(
+            name: "TokiApp",
+            dependencies: ["TokiCore"]
+        ),
+        .testTarget(
+            name: "TokiCoreTests",
+            dependencies: ["TokiCore"]
+        ),
+        .testTarget(
+            name: "TokiAppTests",
+            dependencies: ["TokiApp"]
+        )
+    ]
+)

--- a/Sources/TokiApp/AppShellModel.swift
+++ b/Sources/TokiApp/AppShellModel.swift
@@ -1,0 +1,417 @@
+import AppKit
+import Combine
+import Foundation
+import TokiCore
+
+@MainActor
+final class AppShellModel: ObservableObject {
+    enum AuthenticationState: Equatable {
+        case signedOut
+        case signedIn
+    }
+
+    enum PermissionPreset: String, CaseIterable, Identifiable {
+        case ready
+        case microphoneDenied
+        case inputMonitoringDenied
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .ready:
+                "Ready"
+            case .microphoneDenied:
+                "Microphone Denied"
+            case .inputMonitoringDenied:
+                "Shortcut Unavailable"
+            }
+        }
+
+    }
+
+    enum MenuBarStatus: Equatable {
+        case signedOut
+        case connected
+        case listening
+        case requestingFloor
+        case speaking
+        case floorBusy
+        case microphoneBlocked
+        case shortcutBlocked
+        case reconnecting
+        case p2pUnavailable
+
+        var label: String {
+            switch self {
+            case .signedOut:
+                "Signed Out"
+            case .connected:
+                "Connected"
+            case .listening:
+                "Listening"
+            case .requestingFloor:
+                "Requesting"
+            case .speaking:
+                "Speaking"
+            case .floorBusy:
+                "Floor Busy"
+            case .microphoneBlocked:
+                "Mic Blocked"
+            case .shortcutBlocked:
+                "Shortcut Blocked"
+            case .reconnecting:
+                "Reconnecting"
+            case .p2pUnavailable:
+                "P2P Unavailable"
+            }
+        }
+
+        var symbolName: String {
+            switch self {
+            case .signedOut:
+                "person.crop.circle.badge.xmark"
+            case .connected:
+                "bolt.horizontal.circle"
+            case .listening:
+                "waveform.circle"
+            case .requestingFloor:
+                "hourglass.circle"
+            case .speaking:
+                "mic.circle.fill"
+            case .floorBusy:
+                "person.wave.2"
+            case .microphoneBlocked:
+                "mic.slash.circle"
+            case .shortcutBlocked:
+                "keyboard.badge.ellipsis"
+            case .reconnecting:
+                "arrow.triangle.2.circlepath.circle"
+            case .p2pUnavailable:
+                "wifi.slash"
+            }
+        }
+    }
+
+    struct RoomSummary: Identifiable, Equatable {
+        let id: ConversationID
+        let title: String
+        let subtitle: String
+        let participants: Int
+    }
+
+    @Published private(set) var authenticationState: AuthenticationState = .signedOut
+    @Published private(set) var activeConversationID: ConversationID?
+    @Published private(set) var menuBarStatus: MenuBarStatus = .signedOut
+    @Published private(set) var activityLabel = "Signed out"
+    @Published private(set) var detailStatus = "Select a room to listen."
+    @Published private(set) var canUseManualPTT = false
+    @Published private(set) var canUseKeyboardPTT = false
+    @Published var isOutputMuted = false
+    @Published var permissionPreset: PermissionPreset = .ready {
+        didSet { rebuildSessionForPermissions() }
+    }
+    @Published var launchAtLogin = false
+    @Published var diagnosticsOptIn = false
+    @Published var selectedInputDeviceID = "input-built-in"
+    @Published var selectedOutputDeviceID = "output-system"
+    @Published var pushToTalkShortcutLabel = "Shift + Command + Space"
+
+    let rooms: [RoomSummary] = [
+        RoomSummary(id: ConversationID("design"), title: "Design", subtitle: "3 listening", participants: 4),
+        RoomSummary(id: ConversationID("ops"), title: "Ops", subtitle: "Floor controlled", participants: 6),
+        RoomSummary(id: ConversationID("founders"), title: "Founders", subtitle: "Private room", participants: 3)
+    ]
+
+    private let settingsStore = LocalSettingsStore(defaults: .standard)
+    private let permissionCoordinator: PermissionCoordinating
+    private var session: AppSessionState?
+    private var delayedGrantTask: Task<Void, Never>?
+    private var isShortcutHeld = false
+
+    init(permissionCoordinator: PermissionCoordinating = PermissionCoordinator.live()) {
+        self.permissionCoordinator = permissionCoordinator
+        loadSettings()
+    }
+
+    var selectedRoom: RoomSummary? {
+        guard let activeConversationID else { return nil }
+        return rooms.first { $0.id == activeConversationID }
+    }
+
+    func signInMockUser() {
+        authenticationState = .signedIn
+        rebuildSessionForPermissions()
+        if let firstRoom = rooms.first {
+            selectRoom(firstRoom.id)
+        }
+    }
+
+    func signOut() {
+        delayedGrantTask?.cancel()
+        session = nil
+        authenticationState = .signedOut
+        activeConversationID = nil
+        menuBarStatus = .signedOut
+        activityLabel = "Signed out"
+        detailStatus = "Open Toki to join a room."
+        canUseManualPTT = false
+        canUseKeyboardPTT = false
+    }
+
+    func openMainWindow() {
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.windows.first?.makeKeyAndOrderFront(nil)
+    }
+
+    func selectRoom(_ conversationID: ConversationID) {
+        guard let session else { return }
+        session.selectConversation(id: conversationID)
+        activeConversationID = conversationID
+        syncFromSession()
+    }
+
+    func startManualPushToTalk() {
+        guard let session else { return }
+        session.pushToTalkPressed(source: .mouse)
+        syncFromSession()
+        scheduleFloorGrantForCurrentUser(usingKeyboardSource: false)
+    }
+
+    func startShortcutPushToTalk() {
+        guard let session else { return }
+        session.pushToTalkPressed(source: .keyboard)
+        syncFromSession()
+        scheduleFloorGrantForCurrentUser(usingKeyboardSource: true)
+    }
+
+    @discardableResult
+    func handleShortcutPressed() -> Bool {
+        guard !isShortcutHeld, canUseKeyboardPTT else {
+            return false
+        }
+
+        isShortcutHeld = true
+        startShortcutPushToTalk()
+        return true
+    }
+
+    func handleShortcutReleased() {
+        guard isShortcutHeld else {
+            return
+        }
+
+        isShortcutHeld = false
+        stopPushToTalk()
+    }
+
+    func stopPushToTalk() {
+        delayedGrantTask?.cancel()
+        session?.pushToTalkReleased()
+        syncFromSession()
+    }
+
+    func requestMicrophonePermission() async {
+        let status = await permissionCoordinator.requestMicrophonePermission()
+        permissionPreset = status == .denied ? .microphoneDenied : .ready
+        rebuildSessionForPermissions()
+    }
+
+    func refreshInputMonitoringPermission() {
+        let status = permissionCoordinator.refreshInputMonitoringPermission()
+        permissionPreset = status == .denied ? .inputMonitoringDenied : .ready
+        rebuildSessionForPermissions()
+    }
+
+    func simulateReconnect() {
+        session?.connectionChanged(.reconnecting)
+        syncFromSession()
+    }
+
+    func simulateP2PUnavailable() {
+        session?.connectionChanged(.p2pUnavailable)
+        syncFromSession()
+    }
+
+    func restoreConnectedState() {
+        session?.connectionChanged(.listening)
+        syncFromSession()
+    }
+
+    func simulateRemoteSpeaker() {
+        guard let session else { return }
+        session.floorGrantReceived(speakerID: UserID("teammate"))
+        syncFromSession()
+    }
+
+    func saveSettings() {
+        let preferences = DevicePreferences(
+            selectedInputDeviceID: selectedInputDeviceID,
+            selectedOutputDeviceID: selectedOutputDeviceID,
+            pushToTalkShortcut: PushToTalkShortcut(keyCode: 49, modifiers: [.command, .shift]),
+            launchAtLogin: launchAtLogin,
+            diagnosticsOptIn: diagnosticsOptIn
+        )
+
+        settingsStore.save(preferences)
+    }
+
+    private func rebuildSessionForPermissions() {
+        guard authenticationState == .signedIn else { return }
+
+        delayedGrantTask?.cancel()
+        isShortcutHeld = false
+        let session: AppSessionState
+        switch permissionPreset {
+        case .ready:
+            session = AppSessionState.mockSignedIn(
+                microphone: .granted,
+                inputMonitoring: .granted
+            )
+        case .microphoneDenied:
+            session = AppSessionState.mockSignedIn(
+                microphone: .denied,
+                inputMonitoring: .granted
+            )
+        case .inputMonitoringDenied:
+            session = AppSessionState.mockSignedIn(
+                microphone: .granted,
+                inputMonitoring: .denied
+            )
+        }
+        self.session = session
+
+        if let activeConversationID {
+            session.selectConversation(id: activeConversationID)
+        }
+
+        syncFromSession()
+    }
+
+    private func scheduleFloorGrantForCurrentUser(usingKeyboardSource: Bool) {
+        guard let session else { return }
+        delayedGrantTask?.cancel()
+        delayedGrantTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(250))
+            guard let self, !Task.isCancelled else {
+                return
+            }
+
+            let canStart =
+                if usingKeyboardSource {
+                    self.session?.canStartPushToTalk(source: .keyboard) == true
+                } else {
+                    self.session?.canStartPushToTalk(source: .mouse) == true
+                }
+
+            guard canStart else {
+                return
+            }
+
+            self.session?.floorGrantReceived(speakerID: session.localUserID)
+            self.syncFromSession()
+        }
+    }
+
+    private func syncFromSession() {
+        guard let session else { return }
+
+        canUseManualPTT = session.canStartPushToTalk(source: .mouse)
+        canUseKeyboardPTT = session.canStartPushToTalk(source: .keyboard)
+        menuBarStatus = resolveMenuBarStatus(session: session)
+        activityLabel = resolveActivityLabel(session: session)
+        detailStatus = resolveDetailStatus(session: session)
+    }
+
+    private func resolveMenuBarStatus(session: AppSessionState) -> MenuBarStatus {
+        switch session.activity {
+        case .idle, .connected:
+            .connected
+        case .speaking:
+            .speaking
+        case .reconnecting:
+            .reconnecting
+        case .p2pUnavailable:
+            .p2pUnavailable
+        case .listening:
+            .listening
+        case .requestingFloor:
+            .requestingFloor
+        case .floorBusy:
+            .floorBusy
+        case .permissionDenied(.microphone):
+            .microphoneBlocked
+        case .permissionDenied(.inputMonitoring):
+            .shortcutBlocked
+        @unknown default:
+            .connected
+        }
+    }
+
+    private func resolveActivityLabel(session: AppSessionState) -> String {
+        switch session.activity {
+        case .idle:
+            "Connected"
+        case .connected:
+            "Connected"
+        case .listening:
+            "Listening"
+        case .requestingFloor:
+            "Requesting floor"
+        case .speaking:
+            "Speaking"
+        case .floorBusy:
+            "Floor busy"
+        case .reconnecting:
+            "Reconnecting"
+        case .p2pUnavailable:
+            "P2P unavailable"
+        case .permissionDenied(.microphone):
+            "Microphone permission required"
+        case .permissionDenied(_):
+            "Shortcut permission required"
+        @unknown default:
+            "Connected"
+        }
+    }
+
+    private func resolveDetailStatus(session: AppSessionState) -> String {
+        switch session.activity {
+        case .idle:
+            "Join a room to start listening."
+        case .connected:
+            "Select a room to start listening."
+        case .listening:
+            "Ready to listen in the active room."
+        case .requestingFloor:
+            "Waiting for the floor token."
+        case .speaking:
+            "PTT is held. Release to stop transmitting."
+        case .floorBusy:
+            "Another teammate has the floor."
+        case .reconnecting:
+            "Realtime link dropped. Rejoin the room when connected."
+        case .p2pUnavailable:
+            "Direct peer path is unavailable. Toki will not transmit."
+        case .permissionDenied(.microphone):
+            "Microphone access is required before PTT can start."
+        case .permissionDenied(_):
+            "Global shortcut access is unavailable. Manual PTT still works."
+        @unknown default:
+            "Connected."
+        }
+    }
+
+    private func loadSettings() {
+        guard let preferences = settingsStore.load() else { return }
+
+        selectedInputDeviceID = preferences.selectedInputDeviceID ?? selectedInputDeviceID
+        selectedOutputDeviceID = preferences.selectedOutputDeviceID ?? selectedOutputDeviceID
+        launchAtLogin = preferences.launchAtLogin
+        diagnosticsOptIn = preferences.diagnosticsOptIn
+
+        if let shortcut = preferences.pushToTalkShortcut, shortcut.keyCode == 49, shortcut.modifiers == [.command, .shift] {
+            pushToTalkShortcutLabel = "Shift + Command + Space"
+        }
+    }
+}

--- a/Sources/TokiApp/AppShellView.swift
+++ b/Sources/TokiApp/AppShellView.swift
@@ -1,0 +1,269 @@
+import SwiftUI
+
+struct AppShellView: View {
+    @ObservedObject var model: AppShellModel
+
+    var body: some View {
+        Group {
+            if model.authenticationState == .signedOut {
+                SignedOutView(model: model)
+            } else {
+                SignedInShellView(model: model)
+            }
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+}
+
+private struct SignedOutView: View {
+    @ObservedObject var model: AppShellModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("Toki")
+                .font(.system(size: 28, weight: .semibold))
+            Text("Private team push-to-talk, scoped to one active room.")
+                .foregroundStyle(.secondary)
+            Picker("Permission preset", selection: $model.permissionPreset) {
+                ForEach(AppShellModel.PermissionPreset.allCases) { preset in
+                    Text(preset.title).tag(preset)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 420)
+
+            Button("Sign In Mock User") {
+                model.signInMockUser()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .padding(40)
+    }
+}
+
+private struct SignedInShellView: View {
+    @ObservedObject var model: AppShellModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                ConversationSidebar(model: model)
+                Divider()
+                ActiveRoomPanel(model: model)
+            }
+            Divider()
+            StatusStrip(model: model)
+        }
+        .toolbar {
+            ToolbarItemGroup {
+                Button("Reconnect") {
+                    model.simulateReconnect()
+                }
+                Button("P2P Down") {
+                    model.simulateP2PUnavailable()
+                }
+                Button("Restore") {
+                    model.restoreConnectedState()
+                }
+                Button("Remote Floor") {
+                    model.simulateRemoteSpeaker()
+                }
+                Button("Sign Out") {
+                    model.signOut()
+                }
+            }
+        }
+    }
+}
+
+private struct ConversationSidebar: View {
+    @ObservedObject var model: AppShellModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Rooms")
+                .font(.headline)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+
+            List(model.rooms, selection: Binding(
+                get: { model.activeConversationID },
+                set: { newValue in
+                    guard let newValue else { return }
+                    model.selectRoom(newValue)
+                }
+            )) { room in
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(room.title)
+                    Text(room.subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+            .listStyle(.sidebar)
+        }
+        .frame(minWidth: 220, idealWidth: 240, maxWidth: 260, maxHeight: .infinity)
+    }
+}
+
+private struct ActiveRoomPanel: View {
+    @ObservedObject var model: AppShellModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(model.selectedRoom?.title ?? "No Room Selected")
+                        .font(.title2.weight(.semibold))
+                    Text(model.detailStatus)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Picker("Permissions", selection: $model.permissionPreset) {
+                    ForEach(AppShellModel.PermissionPreset.allCases) { preset in
+                        Text(preset.title).tag(preset)
+                    }
+                }
+                .frame(width: 220)
+            }
+
+            if model.permissionPreset == .microphoneDenied {
+                PermissionBanner(
+                    title: "Microphone access is required",
+                    message: "Toki fails closed when microphone permission is denied. PTT remains disabled until access is restored.",
+                    actionTitle: "Request Access",
+                    action: {
+                        Task { await model.requestMicrophonePermission() }
+                    }
+                )
+            }
+
+            if model.permissionPreset == .inputMonitoringDenied {
+                PermissionBanner(
+                    title: "Global shortcut access is unavailable",
+                    message: "Keyboard PTT is blocked, but the in-window hold-to-talk button remains available.",
+                    actionTitle: "Refresh Access",
+                    action: model.refreshInputMonitoringPermission
+                )
+            }
+
+            HStack(spacing: 12) {
+                SummaryMetric(title: "Participants", value: "\(model.selectedRoom?.participants ?? 0)")
+                SummaryMetric(title: "Output", value: model.isOutputMuted ? "Muted" : "Live")
+                SummaryMetric(title: "Shortcut", value: model.canUseKeyboardPTT ? "Ready" : "Blocked")
+            }
+
+            Spacer(minLength: 0)
+
+            HStack(spacing: 12) {
+                HoldToTalkButton(
+                    title: "Hold To Talk",
+                    isEnabled: model.canUseManualPTT,
+                    onPress: model.startManualPushToTalk,
+                    onRelease: model.stopPushToTalk
+                )
+                Button(model.isOutputMuted ? "Unmute Output" : "Mute Output") {
+                    model.isOutputMuted.toggle()
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}
+
+private struct StatusStrip: View {
+    @ObservedObject var model: AppShellModel
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: model.menuBarStatus.symbolName)
+            Text(model.activityLabel)
+                .fontWeight(.medium)
+            Text(model.detailStatus)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Spacer()
+            Text(model.pushToTalkShortcutLabel)
+                .foregroundStyle(.secondary)
+            Button("Settings") {
+                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            }
+            .buttonStyle(.link)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+}
+
+private struct PermissionBanner: View {
+    let title: String
+    let message: String
+    let actionTitle: String
+    let action: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title)
+                    .font(.headline)
+                Text(message)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button(actionTitle, action: action)
+        }
+        .padding(14)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct SummaryMetric: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.headline)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct HoldToTalkButton: View {
+    let title: String
+    let isEnabled: Bool
+    let onPress: () -> Void
+    let onRelease: () -> Void
+    @State private var isHolding = false
+
+    var body: some View {
+        Button(title) {}
+            .buttonStyle(.borderedProminent)
+            .disabled(!isEnabled)
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        guard !isHolding else { return }
+                        isHolding = true
+                        onPress()
+                    }
+                    .onEnded { _ in
+                        isHolding = false
+                        onRelease()
+                    }
+            )
+    }
+}

--- a/Sources/TokiApp/GlobalShortcutController.swift
+++ b/Sources/TokiApp/GlobalShortcutController.swift
@@ -1,0 +1,62 @@
+import AppKit
+
+@MainActor
+final class GlobalShortcutController {
+    private weak var model: AppShellModel?
+    private var keyDownMonitor: Any?
+    private var keyUpMonitor: Any?
+    private var globalKeyDownMonitor: Any?
+    private var globalKeyUpMonitor: Any?
+
+    init(model: AppShellModel) {
+        self.model = model
+        installMonitors()
+    }
+
+    deinit {
+        if let keyDownMonitor {
+            NSEvent.removeMonitor(keyDownMonitor)
+        }
+
+        if let keyUpMonitor {
+            NSEvent.removeMonitor(keyUpMonitor)
+        }
+
+        if let globalKeyDownMonitor {
+            NSEvent.removeMonitor(globalKeyDownMonitor)
+        }
+
+        if let globalKeyUpMonitor {
+            NSEvent.removeMonitor(globalKeyUpMonitor)
+        }
+    }
+
+    private func installMonitors() {
+        keyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard self?.matchesShortcut(event) == true else { return event }
+            guard event.isARepeat == false else { return nil }
+            _ = self?.model?.handleShortcutPressed()
+            return nil
+        }
+
+        keyUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyUp) { [weak self] event in
+            guard self?.matchesShortcut(event) == true else { return event }
+            self?.model?.handleShortcutReleased()
+            return nil
+        }
+
+        globalKeyDownMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard self?.matchesShortcut(event) == true, event.isARepeat == false else { return }
+            _ = self?.model?.handleShortcutPressed()
+        }
+
+        globalKeyUpMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyUp) { [weak self] event in
+            guard self?.matchesShortcut(event) == true else { return }
+            self?.model?.handleShortcutReleased()
+        }
+    }
+
+    private func matchesShortcut(_ event: NSEvent) -> Bool {
+        event.keyCode == 49 && event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift]
+    }
+}

--- a/Sources/TokiApp/MenuBarController.swift
+++ b/Sources/TokiApp/MenuBarController.swift
@@ -1,0 +1,90 @@
+import AppKit
+import Combine
+import Foundation
+
+@MainActor
+final class MenuBarController {
+    private let model: AppShellModel
+    private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(model: AppShellModel) {
+        self.model = model
+        bind()
+        rebuildMenu()
+    }
+
+    private func bind() {
+        model.objectWillChange
+            .sink { [weak self] in
+                DispatchQueue.main.async {
+                    self?.rebuildMenu()
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func rebuildMenu() {
+        if let button = statusItem.button {
+            button.image = NSImage(
+                systemSymbolName: model.menuBarStatus.symbolName,
+                accessibilityDescription: model.menuBarStatus.label
+            )
+            button.imagePosition = .imageLeading
+            button.title = " \(model.menuBarStatus.label)"
+        }
+
+        let menu = NSMenu()
+        menu.addItem(NSMenuItem(title: model.activityLabel, action: nil, keyEquivalent: ""))
+        menu.addItem(.separator())
+
+        let openItem = NSMenuItem(title: "Open Toki", action: #selector(openToki), keyEquivalent: "")
+        openItem.target = self
+        menu.addItem(openItem)
+
+        let muteItem = NSMenuItem(title: model.isOutputMuted ? "Unmute Output" : "Mute Output", action: #selector(toggleMute), keyEquivalent: "")
+        muteItem.target = self
+        menu.addItem(muteItem)
+
+        let roomItem = NSMenuItem(title: "Switch Active Room", action: nil, keyEquivalent: "")
+        let roomMenu = NSMenu()
+        for (index, room) in model.rooms.enumerated() {
+            let item = NSMenuItem(title: room.title, action: #selector(selectRoom(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = index
+            item.state = model.activeConversationID == room.id ? .on : .off
+            roomMenu.addItem(item)
+        }
+        roomItem.submenu = roomMenu
+        menu.addItem(roomItem)
+
+        menu.addItem(.separator())
+        let quitItem = NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q")
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        statusItem.menu = menu
+    }
+
+    @objc
+    private func openToki() {
+        model.openMainWindow()
+    }
+
+    @objc
+    private func toggleMute() {
+        model.isOutputMuted.toggle()
+    }
+
+    @objc
+    private func selectRoom(_ sender: NSMenuItem) {
+        guard let index = sender.representedObject as? Int, model.rooms.indices.contains(index) else { return }
+        model.selectRoom(model.rooms[index].id)
+        model.openMainWindow()
+    }
+
+    @objc
+    private func quit() {
+        NSApp.terminate(nil)
+    }
+}

--- a/Sources/TokiApp/SettingsView.swift
+++ b/Sources/TokiApp/SettingsView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var model: AppShellModel
+
+    var body: some View {
+        Form {
+            Picker("Microphone", selection: $model.selectedInputDeviceID) {
+                Text("Built-in Microphone").tag("input-built-in")
+                Text("Studio USB").tag("input-studio")
+            }
+
+            Picker("Output Device", selection: $model.selectedOutputDeviceID) {
+                Text("System Default").tag("output-system")
+                Text("AirPods Pro").tag("output-airpods")
+            }
+
+            HStack {
+                Text("PTT Shortcut")
+                Spacer()
+                Text(model.pushToTalkShortcutLabel)
+                    .foregroundStyle(.secondary)
+            }
+
+            Toggle("Launch At Login", isOn: $model.launchAtLogin)
+            Toggle("Diagnostics Opt-In", isOn: $model.diagnosticsOptIn)
+
+            Text("Global shortcut capture stays local in this slice. Audio transport and device activation are intentionally not implemented here.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .formStyle(.grouped)
+        .padding(20)
+        .onChange(of: model.selectedInputDeviceID) { _, _ in model.saveSettings() }
+        .onChange(of: model.selectedOutputDeviceID) { _, _ in model.saveSettings() }
+        .onChange(of: model.launchAtLogin) { _, _ in model.saveSettings() }
+        .onChange(of: model.diagnosticsOptIn) { _, _ in model.saveSettings() }
+    }
+}

--- a/Sources/TokiApp/TokiApp.swift
+++ b/Sources/TokiApp/TokiApp.swift
@@ -1,0 +1,42 @@
+import AppKit
+import SwiftUI
+import TokiCore
+
+@main
+struct TokiApp: App {
+    @NSApplicationDelegateAdaptor(TokiApplicationDelegate.self) private var appDelegate
+    @StateObject private var model = AppEnvironment.shared.model
+
+    var body: some Scene {
+        WindowGroup("Toki") {
+            AppShellView(model: model)
+                .frame(minWidth: 920, minHeight: 620)
+        }
+        .windowResizability(.contentMinSize)
+
+        Settings {
+            SettingsView(model: model)
+                .frame(width: 520, height: 340)
+        }
+    }
+}
+
+@MainActor
+final class AppEnvironment {
+    static let shared = AppEnvironment()
+
+    let model = AppShellModel()
+
+    private init() {}
+}
+
+final class TokiApplicationDelegate: NSObject, NSApplicationDelegate {
+    private var menuBarController: MenuBarController?
+    private var globalShortcutController: GlobalShortcutController?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let model = AppEnvironment.shared.model
+        menuBarController = MenuBarController(model: model)
+        globalShortcutController = GlobalShortcutController(model: model)
+    }
+}

--- a/Sources/TokiCore/AppSessionState.swift
+++ b/Sources/TokiCore/AppSessionState.swift
@@ -1,0 +1,206 @@
+import Combine
+import Foundation
+
+public enum AuthState: Equatable, Sendable {
+    case signedOut
+    case signedIn(userID: UserID)
+}
+
+public enum RealtimeConnectionState: Equatable, Sendable {
+    case disconnected
+    case connected
+    case listening
+    case reconnecting
+    case p2pUnavailable
+}
+
+public enum FloorBlockReason: Equatable, Sendable {
+    case microphoneDenied
+    case inputMonitoringDenied
+}
+
+public enum FloorState: Equatable, Sendable {
+    case idle
+    case requesting(localUserID: UserID)
+    case granted(speakerID: UserID)
+    case busy(speakerID: UserID)
+    case blocked(reason: FloorBlockReason)
+}
+
+public enum SessionActivity: Equatable, Sendable {
+    case idle
+    case connected
+    case listening
+    case requestingFloor
+    case speaking
+    case floorBusy
+    case reconnecting
+    case p2pUnavailable
+    case permissionDenied(PermissionKind)
+}
+
+public struct PermissionState: Equatable, Sendable {
+    public let microphone: PermissionStatus
+    public let inputMonitoring: PermissionStatus
+
+    public init(microphone: PermissionStatus, inputMonitoring: PermissionStatus) {
+        self.microphone = microphone
+        self.inputMonitoring = inputMonitoring
+    }
+}
+
+public final class AppSessionState: ObservableObject, @unchecked Sendable {
+    @Published public private(set) var auth: AuthState
+    @Published public private(set) var localUserID: UserID
+    @Published public private(set) var activeConversationID: ConversationID?
+    @Published public private(set) var realtimeConnection: RealtimeConnectionState
+    @Published public private(set) var floor: FloorState
+    @Published public private(set) var activity: SessionActivity
+    @Published public private(set) var devicePreferences: DevicePreferences
+
+    private let permissions: PermissionCoordinating
+    private var isPushToTalkActive = false
+
+    public init(
+        localUserID: UserID,
+        permissions: PermissionCoordinating,
+        realtimeConnection: RealtimeConnectionState = .disconnected,
+        floor: FloorState = .idle,
+        activity: SessionActivity = .idle,
+        devicePreferences: DevicePreferences = .default
+    ) {
+        self.auth = .signedIn(userID: localUserID)
+        self.localUserID = localUserID
+        self.permissions = permissions
+        self.realtimeConnection = realtimeConnection
+        self.floor = floor
+        self.activity = activity
+        self.devicePreferences = devicePreferences
+    }
+
+    public static func mockSignedIn(
+        localUserID: UserID = UserID("local-user"),
+        microphone: PermissionStatus = .granted,
+        inputMonitoring: PermissionStatus = .granted
+    ) -> AppSessionState {
+        AppSessionState(
+            localUserID: localUserID,
+            permissions: PermissionCoordinator(
+                microphonePermission: microphone,
+                inputMonitoringPermission: inputMonitoring
+            )
+        )
+    }
+
+    public var permissionState: PermissionState {
+        PermissionState(
+            microphone: permissions.microphonePermission,
+            inputMonitoring: permissions.inputMonitoringPermission
+        )
+    }
+
+    public func updateDevicePreferences(_ preferences: DevicePreferences) {
+        devicePreferences = preferences
+    }
+
+    public func selectConversation(id: ConversationID) {
+        activeConversationID = id
+        realtimeConnection = .listening
+        floor = .idle
+        activity = .listening
+    }
+
+    public func canStartPushToTalk(source: PushToTalkSource) -> Bool {
+        guard activeConversationID != nil else {
+            return false
+        }
+
+        guard realtimeConnection == .listening else {
+            return false
+        }
+
+        guard permissions.microphonePermission == .granted else {
+            return false
+        }
+
+        if source == .keyboard && permissions.inputMonitoringPermission == .denied {
+            return false
+        }
+
+        guard floor == .idle else {
+            return false
+        }
+
+        return true
+    }
+
+    public func pushToTalkPressed(source: PushToTalkSource) {
+        guard activeConversationID != nil else {
+            return
+        }
+
+        guard permissions.microphonePermission == .granted else {
+            isPushToTalkActive = false
+            floor = .blocked(reason: .microphoneDenied)
+            activity = .permissionDenied(.microphone)
+            return
+        }
+
+        guard source != .keyboard || permissions.inputMonitoringPermission == .granted else {
+            isPushToTalkActive = false
+            floor = .blocked(reason: .inputMonitoringDenied)
+            activity = .permissionDenied(.inputMonitoring)
+            return
+        }
+
+        guard realtimeConnection == .listening, floor == .idle else {
+            isPushToTalkActive = false
+            return
+        }
+
+        isPushToTalkActive = true
+        floor = .requesting(localUserID: localUserID)
+        activity = .requestingFloor
+    }
+
+    public func floorGrantReceived(speakerID: UserID) {
+        if speakerID == localUserID && isPushToTalkActive {
+            floor = .granted(speakerID: speakerID)
+            activity = .speaking
+            return
+        }
+
+        floor = .busy(speakerID: speakerID)
+        activity = .floorBusy
+    }
+
+    public func pushToTalkReleased() {
+        isPushToTalkActive = false
+
+        guard activeConversationID != nil else {
+            floor = .idle
+            activity = .idle
+            return
+        }
+
+        floor = .idle
+        activity = .listening
+    }
+
+    public func connectionChanged(_ state: RealtimeConnectionState) {
+        realtimeConnection = state
+
+        switch state {
+        case .disconnected:
+            activity = .idle
+        case .connected:
+            activity = .connected
+        case .listening:
+            activity = activeConversationID == nil ? .idle : .listening
+        case .reconnecting:
+            activity = .reconnecting
+        case .p2pUnavailable:
+            activity = .p2pUnavailable
+        }
+    }
+}

--- a/Sources/TokiCore/Identifiers.swift
+++ b/Sources/TokiCore/Identifiers.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct UserID: RawRepresentable, Hashable, Codable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: String) {
+        self.init(rawValue: rawValue)
+    }
+}
+
+public struct ConversationID: RawRepresentable, Hashable, Codable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: String) {
+        self.init(rawValue: rawValue)
+    }
+}

--- a/Sources/TokiCore/LocalSettingsStore.swift
+++ b/Sources/TokiCore/LocalSettingsStore.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+public struct PushToTalkShortcut: Codable, Equatable, Sendable {
+    public struct Modifiers: OptionSet, Codable, Equatable, Sendable {
+        public let rawValue: Int
+
+        public static let command = Modifiers(rawValue: 1 << 0)
+        public static let shift = Modifiers(rawValue: 1 << 1)
+        public static let option = Modifiers(rawValue: 1 << 2)
+        public static let control = Modifiers(rawValue: 1 << 3)
+
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+    }
+
+    public let keyCode: Int
+    public let modifiers: Modifiers
+
+    public init(keyCode: Int, modifiers: Modifiers) {
+        self.keyCode = keyCode
+        self.modifiers = modifiers
+    }
+}
+
+public struct DevicePreferences: Codable, Equatable, Sendable {
+    public let selectedInputDeviceID: String?
+    public let selectedOutputDeviceID: String?
+    public let pushToTalkShortcut: PushToTalkShortcut?
+    public let launchAtLogin: Bool
+    public let diagnosticsOptIn: Bool
+
+    public init(
+        selectedInputDeviceID: String?,
+        selectedOutputDeviceID: String?,
+        pushToTalkShortcut: PushToTalkShortcut?,
+        launchAtLogin: Bool,
+        diagnosticsOptIn: Bool
+    ) {
+        self.selectedInputDeviceID = selectedInputDeviceID
+        self.selectedOutputDeviceID = selectedOutputDeviceID
+        self.pushToTalkShortcut = pushToTalkShortcut
+        self.launchAtLogin = launchAtLogin
+        self.diagnosticsOptIn = diagnosticsOptIn
+    }
+
+    public static let `default` = DevicePreferences(
+        selectedInputDeviceID: nil,
+        selectedOutputDeviceID: nil,
+        pushToTalkShortcut: PushToTalkShortcut(keyCode: 49, modifiers: [.command, .shift]),
+        launchAtLogin: false,
+        diagnosticsOptIn: false
+    )
+}
+
+public protocol SettingsStoring: Sendable {
+    func load() -> DevicePreferences?
+    func save(_ preferences: DevicePreferences)
+}
+
+public final class LocalSettingsStore: SettingsStoring, @unchecked Sendable {
+    private enum Keys {
+        static let devicePreferences = "devicePreferences"
+    }
+
+    private let defaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func load() -> DevicePreferences? {
+        guard let data = defaults.data(forKey: Keys.devicePreferences) else {
+            return nil
+        }
+
+        return try? decoder.decode(DevicePreferences.self, from: data)
+    }
+
+    public func save(_ preferences: DevicePreferences) {
+        guard let data = try? encoder.encode(preferences) else {
+            defaults.removeObject(forKey: Keys.devicePreferences)
+            return
+        }
+
+        defaults.set(data, forKey: Keys.devicePreferences)
+    }
+}

--- a/Sources/TokiCore/PermissionCoordinator.swift
+++ b/Sources/TokiCore/PermissionCoordinator.swift
@@ -1,0 +1,105 @@
+import Foundation
+#if canImport(ApplicationServices)
+import ApplicationServices
+#endif
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
+
+public enum PermissionKind: Equatable, Sendable {
+    case microphone
+    case inputMonitoring
+}
+
+public enum PermissionStatus: Equatable, Sendable {
+    case notDetermined
+    case granted
+    case denied
+}
+
+public protocol PermissionCoordinating: Sendable {
+    var microphonePermission: PermissionStatus { get }
+    var inputMonitoringPermission: PermissionStatus { get }
+    func requestMicrophonePermission() async -> PermissionStatus
+    func refreshInputMonitoringPermission() -> PermissionStatus
+}
+
+public final class PermissionCoordinator: PermissionCoordinating, @unchecked Sendable {
+    public private(set) var microphonePermission: PermissionStatus
+    public private(set) var inputMonitoringPermission: PermissionStatus
+
+    private let microphoneRequester: @Sendable () async -> PermissionStatus
+    private let inputMonitoringReader: @Sendable () -> PermissionStatus
+
+    public init(
+        microphonePermission: PermissionStatus,
+        inputMonitoringPermission: PermissionStatus,
+        microphoneRequester: @escaping @Sendable () async -> PermissionStatus = { .notDetermined },
+        inputMonitoringReader: @escaping @Sendable () -> PermissionStatus = { .notDetermined }
+    ) {
+        self.microphonePermission = microphonePermission
+        self.inputMonitoringPermission = inputMonitoringPermission
+        self.microphoneRequester = microphoneRequester
+        self.inputMonitoringReader = inputMonitoringReader
+    }
+
+    public static func live(inputMonitoringReader: @escaping @Sendable () -> PermissionStatus = { .notDetermined }) -> PermissionCoordinator {
+        let inputReader: @Sendable () -> PermissionStatus = {
+            let status = liveInputMonitoringPermission()
+            return status == .notDetermined ? inputMonitoringReader() : status
+        }
+
+        return PermissionCoordinator(
+            microphonePermission: currentMicrophonePermission(),
+            inputMonitoringPermission: inputReader(),
+            microphoneRequester: { await requestMicrophoneAccess() },
+            inputMonitoringReader: inputReader
+        )
+    }
+
+    public func requestMicrophonePermission() async -> PermissionStatus {
+        let status = await microphoneRequester()
+        microphonePermission = status
+        return status
+    }
+
+    public func refreshInputMonitoringPermission() -> PermissionStatus {
+        let status = inputMonitoringReader()
+        inputMonitoringPermission = status
+        return status
+    }
+
+    private static func currentMicrophonePermission() -> PermissionStatus {
+        #if canImport(AVFoundation)
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
+            return .granted
+        case .denied, .restricted:
+            return .denied
+        case .notDetermined:
+            return .notDetermined
+        @unknown default:
+            return .denied
+        }
+        #else
+        return .notDetermined
+        #endif
+    }
+
+    private static func requestMicrophoneAccess() async -> PermissionStatus {
+        #if canImport(AVFoundation)
+        let granted = await AVCaptureDevice.requestAccess(for: .audio)
+        return granted ? .granted : .denied
+        #else
+        return .notDetermined
+        #endif
+    }
+
+    private static func liveInputMonitoringPermission() -> PermissionStatus {
+        #if canImport(ApplicationServices)
+        return CGPreflightListenEventAccess() ? .granted : .denied
+        #else
+        return .notDetermined
+        #endif
+    }
+}

--- a/Sources/TokiCore/PushToTalkInputController.swift
+++ b/Sources/TokiCore/PushToTalkInputController.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public enum PushToTalkSource: String, Equatable, Sendable {
+    case keyboard
+    case mouse
+}
+
+public enum PushToTalkInputEvent: Equatable, Sendable {
+    case pressed(PushToTalkSource)
+    case released
+}
+
+public protocol PushToTalkInputControlling: AnyObject, Sendable {
+    var onEvent: (@Sendable (PushToTalkInputEvent) -> Void)? { get set }
+    func press(source: PushToTalkSource)
+    func release()
+}
+
+public final class PushToTalkInputController: PushToTalkInputControlling, @unchecked Sendable {
+    public var onEvent: (@Sendable (PushToTalkInputEvent) -> Void)?
+
+    public init() {}
+
+    public func press(source: PushToTalkSource) {
+        onEvent?(.pressed(source))
+    }
+
+    public func release() {
+        onEvent?(.released)
+    }
+}

--- a/Tests/TokiAppTests/AppShellSmokeTests.swift
+++ b/Tests/TokiAppTests/AppShellSmokeTests.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import TokiCore
+import XCTest
+@testable import TokiApp
+
+@MainActor
+final class AppShellSmokeTests: XCTestCase {
+    func testSignedInMockUserSelectsRoomAndEnablesManualPTT() {
+        let model = AppShellModel()
+
+        model.signInMockUser()
+
+        XCTAssertEqual(model.authenticationState, .signedIn)
+        XCTAssertNotNil(model.activeConversationID)
+        XCTAssertEqual(model.menuBarStatus, .listening)
+        XCTAssertTrue(model.canUseManualPTT)
+    }
+
+    func testMicrophoneDeniedDisablesManualPTTAndShowsRecoveryState() {
+        let model = AppShellModel()
+        model.permissionPreset = .microphoneDenied
+        model.signInMockUser()
+
+        model.startManualPushToTalk()
+
+        XCTAssertFalse(model.canUseManualPTT)
+        XCTAssertEqual(model.activityLabel, "Microphone permission required")
+    }
+
+    func testMenuStatusReflectsRequestingBusyAndPermissionStates() {
+        let model = AppShellModel()
+        model.signInMockUser()
+
+        model.startManualPushToTalk()
+        XCTAssertEqual(model.menuBarStatus, .requestingFloor)
+
+        model.stopPushToTalk()
+        model.simulateRemoteSpeaker()
+        XCTAssertEqual(model.menuBarStatus, .floorBusy)
+
+        model.permissionPreset = .microphoneDenied
+        model.startManualPushToTalk()
+        XCTAssertEqual(model.menuBarStatus, .microphoneBlocked)
+    }
+
+    func testShortcutPressIsEdgeTriggeredUntilRelease() {
+        let model = AppShellModel()
+        model.signInMockUser()
+
+        XCTAssertTrue(model.handleShortcutPressed())
+        XCTAssertFalse(model.handleShortcutPressed())
+        model.handleShortcutReleased()
+        XCTAssertTrue(model.handleShortcutPressed())
+    }
+
+    func testLivePermissionCoordinatorCanDriveOnboardingRefresh() async {
+        let coordinator = MutablePermissionCoordinator(
+            microphonePermission: .notDetermined,
+            inputMonitoringPermission: .denied,
+            requestedMicrophoneResult: .granted
+        )
+        let model = AppShellModel(permissionCoordinator: coordinator)
+
+        await model.requestMicrophonePermission()
+        model.refreshInputMonitoringPermission()
+
+        XCTAssertEqual(coordinator.microphonePermission, .granted)
+        XCTAssertEqual(coordinator.inputMonitoringPermission, .denied)
+    }
+
+    func testShellViewCanBeConstructedForSmokeCoverage() {
+        let model = AppShellModel()
+        _ = AppShellView(model: model)
+    }
+}
+
+private final class MutablePermissionCoordinator: PermissionCoordinating, @unchecked Sendable {
+    private(set) var microphonePermission: PermissionStatus
+    private(set) var inputMonitoringPermission: PermissionStatus
+    private let requestedMicrophoneResult: PermissionStatus
+
+    init(
+        microphonePermission: PermissionStatus,
+        inputMonitoringPermission: PermissionStatus,
+        requestedMicrophoneResult: PermissionStatus
+    ) {
+        self.microphonePermission = microphonePermission
+        self.inputMonitoringPermission = inputMonitoringPermission
+        self.requestedMicrophoneResult = requestedMicrophoneResult
+    }
+
+    func requestMicrophonePermission() async -> PermissionStatus {
+        microphonePermission = requestedMicrophoneResult
+        return microphonePermission
+    }
+
+    func refreshInputMonitoringPermission() -> PermissionStatus {
+        inputMonitoringPermission
+    }
+}

--- a/Tests/TokiCoreTests/AppSessionStateTests.swift
+++ b/Tests/TokiCoreTests/AppSessionStateTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import TokiCore
+
+final class AppSessionStateTests: XCTestCase {
+    func testSelectingConversationMovesConnectedUserIntoListeningRoom() {
+        let session = AppSessionState.mockSignedIn()
+
+        session.selectConversation(id: ConversationID("design"))
+
+        XCTAssertEqual(session.activeConversationID, ConversationID("design"))
+        XCTAssertEqual(session.realtimeConnection, .listening)
+        XCTAssertEqual(session.floor, .idle)
+        XCTAssertEqual(session.activity, .listening)
+    }
+
+    func testSessionExposesAuthPermissionsAndDevicePreferences() {
+        let preferences = DevicePreferences(
+            selectedInputDeviceID: "input-built-in",
+            selectedOutputDeviceID: "output-system",
+            pushToTalkShortcut: PushToTalkShortcut(keyCode: 49, modifiers: [.command, .shift]),
+            launchAtLogin: false,
+            diagnosticsOptIn: true
+        )
+        let session = AppSessionState(
+            localUserID: UserID("local-user"),
+            permissions: PermissionCoordinator(
+                microphonePermission: .granted,
+                inputMonitoringPermission: .denied
+            ),
+            devicePreferences: preferences
+        )
+
+        XCTAssertEqual(session.auth, .signedIn(userID: UserID("local-user")))
+        XCTAssertEqual(session.permissionState, PermissionState(microphone: .granted, inputMonitoring: .denied))
+        XCTAssertEqual(session.devicePreferences, preferences)
+    }
+
+    func testHoldingPTTRequestsFloorThenGrantedFloorSpeaksUntilRelease() {
+        let session = AppSessionState.mockSignedIn(
+            microphone: .granted,
+            inputMonitoring: .granted
+        )
+        session.selectConversation(id: ConversationID("ops"))
+
+        session.pushToTalkPressed(source: .keyboard)
+
+        XCTAssertEqual(session.floor, .requesting(localUserID: session.localUserID))
+        XCTAssertEqual(session.activity, .requestingFloor)
+
+        session.floorGrantReceived(speakerID: session.localUserID)
+
+        XCTAssertEqual(session.floor, .granted(speakerID: session.localUserID))
+        XCTAssertEqual(session.activity, .speaking)
+
+        session.pushToTalkReleased()
+
+        XCTAssertEqual(session.floor, .idle)
+        XCTAssertEqual(session.activity, .listening)
+    }
+
+    func testDeniedMicrophoneFailsClosedAndDisablesPTT() {
+        let session = AppSessionState.mockSignedIn(
+            microphone: .denied,
+            inputMonitoring: .granted
+        )
+        session.selectConversation(id: ConversationID("ops"))
+
+        session.pushToTalkPressed(source: .mouse)
+
+        XCTAssertEqual(session.floor, .blocked(reason: .microphoneDenied))
+        XCTAssertEqual(session.activity, .permissionDenied(.microphone))
+        XCTAssertFalse(session.canStartPushToTalk(source: .mouse))
+    }
+
+    func testUnavailableInputMonitoringBlocksKeyboardButAllowsMousePTT() {
+        let session = AppSessionState.mockSignedIn(
+            microphone: .granted,
+            inputMonitoring: .denied
+        )
+        session.selectConversation(id: ConversationID("ops"))
+
+        XCTAssertFalse(session.canStartPushToTalk(source: .keyboard))
+        XCTAssertTrue(session.canStartPushToTalk(source: .mouse))
+
+        session.pushToTalkPressed(source: .mouse)
+
+        XCTAssertEqual(session.floor, .requesting(localUserID: session.localUserID))
+        XCTAssertEqual(session.activity, .requestingFloor)
+    }
+
+    func testRemoteSpeakerMakesLocalUserFloorBusy() {
+        let session = AppSessionState.mockSignedIn()
+        session.selectConversation(id: ConversationID("design"))
+
+        session.floorGrantReceived(speakerID: UserID("teammate"))
+
+        XCTAssertEqual(session.floor, .busy(speakerID: UserID("teammate")))
+        XCTAssertEqual(session.activity, .floorBusy)
+    }
+
+    func testPTTIsBlockedWhileConnectionIsUnsafeOrFloorIsBusy() {
+        let session = AppSessionState.mockSignedIn()
+        session.selectConversation(id: ConversationID("design"))
+
+        session.connectionChanged(.reconnecting)
+        XCTAssertFalse(session.canStartPushToTalk(source: .mouse))
+        session.pushToTalkPressed(source: .mouse)
+        XCTAssertEqual(session.activity, .reconnecting)
+
+        session.connectionChanged(.p2pUnavailable)
+        XCTAssertFalse(session.canStartPushToTalk(source: .mouse))
+        session.pushToTalkPressed(source: .mouse)
+        XCTAssertEqual(session.activity, .p2pUnavailable)
+
+        session.connectionChanged(.listening)
+        session.floorGrantReceived(speakerID: UserID("teammate"))
+        XCTAssertFalse(session.canStartPushToTalk(source: .mouse))
+        session.pushToTalkPressed(source: .mouse)
+        XCTAssertEqual(session.activity, .floorBusy)
+    }
+
+    func testConnectionAndP2PFailuresSurfaceAsActivityStates() {
+        let session = AppSessionState.mockSignedIn()
+
+        session.connectionChanged(.connected)
+        XCTAssertEqual(session.activity, .connected)
+
+        session.connectionChanged(.reconnecting)
+        XCTAssertEqual(session.activity, .reconnecting)
+
+        session.connectionChanged(.p2pUnavailable)
+        XCTAssertEqual(session.activity, .p2pUnavailable)
+    }
+}

--- a/Tests/TokiCoreTests/LocalSettingsStoreTests.swift
+++ b/Tests/TokiCoreTests/LocalSettingsStoreTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import TokiCore
+
+final class LocalSettingsStoreTests: XCTestCase {
+    func testDeviceAndShortcutPreferencesRoundTripThroughUserDefaults() {
+        let defaults = UserDefaults(suiteName: "TokiCoreTests.\(UUID().uuidString)")!
+        let store = LocalSettingsStore(defaults: defaults)
+        let preferences = DevicePreferences(
+            selectedInputDeviceID: "input-built-in",
+            selectedOutputDeviceID: "output-airpods",
+            pushToTalkShortcut: PushToTalkShortcut(keyCode: 49, modifiers: [.command, .shift]),
+            launchAtLogin: true,
+            diagnosticsOptIn: true
+        )
+
+        store.save(preferences)
+
+        XCTAssertEqual(store.load(), preferences)
+    }
+}

--- a/Tests/TokiCoreTests/PushToTalkInputControllerTests.swift
+++ b/Tests/TokiCoreTests/PushToTalkInputControllerTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import XCTest
+@testable import TokiCore
+
+final class PushToTalkInputControllerTests: XCTestCase {
+    func testControllerEmitsPressedAndReleasedEvents() {
+        let controller = PushToTalkInputController()
+        let recorder = EventRecorder()
+        controller.onEvent = { recorder.record($0) }
+
+        controller.press(source: .keyboard)
+        controller.release()
+
+        XCTAssertEqual(recorder.events, [.pressed(.keyboard), .released])
+    }
+}
+
+private final class EventRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedEvents: [PushToTalkInputEvent] = []
+
+    var events: [PushToTalkInputEvent] {
+        lock.withLock { recordedEvents }
+    }
+
+    func record(_ event: PushToTalkInputEvent) {
+        lock.withLock {
+            recordedEvents.append(event)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the first Mac app foundation plan for Toki:

- Adds a SwiftPM package with `TokiCore`, `TokiApp`, and focused test targets.
- Adds enum-backed local app/session state for auth, active conversation, realtime connection, floor control, permissions, and device preferences.
- Adds local settings persistence for input/output devices, PTT shortcut, launch-at-login, and diagnostics opt-in placeholders.
- Adds SwiftUI/AppKit Mac shell with main window, menu bar controller, settings view, permission recovery surfaces, manual PTT, and mock global shortcut handling.
- Preserves the MVP media/privacy boundary: no audio capture, WebRTC media transport, relay, recording, transcription, or durable audio storage.

## Validation

- `rtk swift test` passed: 16 tests, 0 failures.
- `rtk swift build` completed.
- Source/test scan found no forbidden media/relay/recording/audio transport scope terms in the implementation.

## Notes

The PR is opened as a draft by default. The global shortcut path is a foundation implementation using AppKit event monitors and permission-state hooks; later phases can replace or extend it with a lower-level production shortcut registration if needed.