### PR TITLE
[codex] Add strict P2P WebRTC foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The media policy is strict peer-to-peer for the MVP. The backend may coordinate 
 - Auth: invited-email development magic-link flow, bearer session token, client-side Keychain token storage.
 - Conversations: signed-in users can list conversations, create direct/group conversations, and add group members.
 - Realtime: authenticated `/v1/realtime` WebSocket for active-room presence and WebRTC signaling metadata.
+- Strict P2P media foundation: authenticated STUN-only ICE config, client-side TURN/relay rejection, and a protocol-backed peer connection manager for active-room mesh setup.
 
 ## Product Constraints
 
@@ -79,6 +80,7 @@ The Mac app expects the local backend at `http://127.0.0.1:8080` by default.
 - `POST /v1/auth/magic-link` with `{ "email": "user@example.com" }` returns a development magic-link token for invited emails.
 - `POST /v1/auth/session` with `{ "token": "opaque-token", "deviceName": "Alice's MacBook Pro" }` returns a bearer session token, user, membership, and device.
 - `GET /v1/me` returns the current user, team memberships, and registered devices.
+- `GET /v1/ice-config` returns STUN-only ICE servers and `{ "relayPolicy": "disabled" }`.
 - `GET /v1/conversations` returns conversations visible to the signed-in user.
 - `POST /v1/conversations` creates a direct or group conversation.
 - `POST /v1/conversations/{id}/members` adds invited team users to a group conversation.
@@ -102,10 +104,26 @@ Client event types are `room.join`, `room.leave`, `presence.set`, `signal.offer`
 
 Server event types are `room.snapshot`, `presence.updated`, `signal.forwarded`, `error`, and `reconnect.required`.
 
-The WebSocket carries presence, room membership, and WebRTC signaling bodies only. It must not carry raw audio frames. Signaling is forwarded only between devices currently joined to the same authorized conversation.
+The WebSocket carries presence, room membership, and WebRTC signaling bodies only. It must not carry raw audio frames. Signaling is forwarded only between devices currently joined to the same authorized conversation. The client rejects ICE configs with TURN URLs, non-disabled relay policy, or relay ICE candidates.
+
+## Strict P2P WebRTC Status
+
+Implemented in the current foundation:
+
+- Backend `GET /v1/ice-config` requires a bearer session and returns STUN-only ICE config.
+- `TokiAPIClient.iceConfig(sessionToken:)` validates the response before returning it to app code.
+- `StrictP2PICEPolicy` rejects TURN URLs, relay policy changes, and relay ICE candidates.
+- `PeerConnectionManager` creates peer connections from `room.snapshot`, uses lexicographic device IDs for deterministic offerer selection, forwards offer/answer/candidate signaling over the realtime transport, and closes all peer connections when leaving or switching rooms.
+
+Still intentionally pending until the native WebRTC dependency is selected and wired:
+
+- Real native WebRTC peer connection creation.
+- Microphone track attachment from the floor-controlled PTT flow.
+- Remote audio playback through selected output devices.
+- Manual two-client LAN and restrictive-network media tests.
 
 ## Verification Notes
 
 The backend realtime channel intentionally avoids audio paths. Re-check this before merging any future WebRTC, replay, diagnostics, or observability changes.
 
-CI runs the full Swift package tests and Go backend tests on pull requests. Local Go verification requires Go 1.22 or newer to be installed.
+CI runs the full Swift package tests and Go backend tests on pull requests. The phase-04 automated coverage includes strict ICE validation, authenticated ICE config fetching, peer mesh lifecycle/signaling behavior, and the backend ICE config endpoint. Local Go verification requires Go 1.22 or newer to be installed.

--- a/Sources/TokiCore/ICEConfig.swift
+++ b/Sources/TokiCore/ICEConfig.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+public enum ICERelayPolicy: String, Codable, Equatable, Sendable {
+    case disabled
+    case enabled
+}
+
+public struct ICEConfigServer: Codable, Equatable, Sendable {
+    public let urls: [String]
+
+    public init(urls: [String]) {
+        self.urls = urls
+    }
+}
+
+public struct ICEConfigResponse: Codable, Equatable, Sendable {
+    public let iceServers: [ICEConfigServer]
+    public let relayPolicy: ICERelayPolicy
+
+    public init(iceServers: [ICEConfigServer], relayPolicy: ICERelayPolicy) {
+        self.iceServers = iceServers
+        self.relayPolicy = relayPolicy
+    }
+
+    public static func stunOnly(urls: [String]) -> ICEConfigResponse {
+        ICEConfigResponse(iceServers: [ICEConfigServer(urls: urls)], relayPolicy: .disabled)
+    }
+}
+
+public enum StrictP2PICEPolicyError: Error, Equatable, Sendable {
+    case relayPolicyEnabled
+    case missingStunServer
+    case forbiddenRelayURL(String)
+    case forbiddenRelayCandidate
+}
+
+public enum StrictP2PICEPolicy {
+    public static func validate(_ config: ICEConfigResponse) throws {
+        guard config.relayPolicy == .disabled else {
+            throw StrictP2PICEPolicyError.relayPolicyEnabled
+        }
+
+        var hasStunServer = false
+        for url in config.iceServers.flatMap(\.urls) {
+            let normalized = url.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if normalized.hasPrefix("turn:") || normalized.hasPrefix("turns:") {
+                throw StrictP2PICEPolicyError.forbiddenRelayURL(url)
+            }
+            if normalized.hasPrefix("stun:") || normalized.hasPrefix("stuns:") {
+                hasStunServer = true
+            }
+        }
+
+        guard hasStunServer else {
+            throw StrictP2PICEPolicyError.missingStunServer
+        }
+    }
+
+    public static func validateCandidate(_ candidate: String) throws {
+        let fields = candidate.lowercased().split(whereSeparator: \.isWhitespace)
+        let hasRelayType = fields.indices.contains { index in
+            let nextIndex = fields.index(after: index)
+            return fields[index] == "typ" && nextIndex < fields.endIndex && fields[nextIndex] == "relay"
+        }
+        if hasRelayType {
+            throw StrictP2PICEPolicyError.forbiddenRelayCandidate
+        }
+    }
+}

--- a/Sources/TokiCore/PeerConnectionManager.swift
+++ b/Sources/TokiCore/PeerConnectionManager.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+public struct RoomPeer: Codable, Equatable, Sendable {
+    public let connectionID: String
+    public let userID: UserID
+    public let deviceID: DeviceID
+    public let active: Bool
+
+    public init(connectionID: String, userID: UserID, deviceID: DeviceID, active: Bool) {
+        self.connectionID = connectionID
+        self.userID = userID
+        self.deviceID = deviceID
+        self.active = active
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case connectionID = "connectionId"
+        case userID = "userId"
+        case deviceID = "deviceId"
+        case active
+    }
+}
+
+public struct RoomSnapshot: Codable, Equatable, Sendable {
+    public let conversationID: ConversationID
+    public let peers: [RoomPeer]
+
+    public init(conversationID: ConversationID, peers: [RoomPeer]) {
+        self.conversationID = conversationID
+        self.peers = peers
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case conversationID = "conversationId"
+        case peers
+    }
+}
+
+public enum PeerConnectionState: Equatable, Sendable {
+    case connecting
+    case connected
+    case disconnected
+    case failed
+    case closed
+}
+
+public protocol PeerConnectionControlling: Sendable {
+    func makeOffer() async throws -> String
+    func setPublishingEnabled(_ enabled: Bool) async throws
+    func close() async
+}
+
+public protocol PeerConnectionCreating: Sendable {
+    func makePeerConnection(peer: RoomPeer, iceConfig: ICEConfigResponse) throws -> PeerConnectionControlling
+}
+
+public final class PeerConnectionManager<EventID: RealtimeEventIDGenerating>: @unchecked Sendable {
+    public private(set) var peerStates: [DeviceID: PeerConnectionState] = [:]
+    public private(set) var isPublishing = false
+
+    private let localDeviceID: DeviceID
+    private let iceConfig: ICEConfigResponse
+    private let transport: RealtimeTransporting
+    private let peerConnectionFactory: PeerConnectionCreating
+    private let clock: RealtimeClock
+    private var eventID: EventID
+    private var activeConversationID: ConversationID?
+    private var connections: [DeviceID: PeerConnectionControlling] = [:]
+
+    public init(
+        localDeviceID: DeviceID,
+        iceConfig: ICEConfigResponse,
+        transport: RealtimeTransporting,
+        peerConnectionFactory: PeerConnectionCreating,
+        eventID: EventID,
+        clock: RealtimeClock = SystemRealtimeClock()
+    ) {
+        self.localDeviceID = localDeviceID
+        self.iceConfig = iceConfig
+        self.transport = transport
+        self.peerConnectionFactory = peerConnectionFactory
+        self.eventID = eventID
+        self.clock = clock
+    }
+
+    public func joinRoom(_ snapshot: RoomSnapshot) async throws {
+        try StrictP2PICEPolicy.validate(iceConfig)
+        if activeConversationID != nil && activeConversationID != snapshot.conversationID {
+            await closeConnections()
+        }
+
+        activeConversationID = snapshot.conversationID
+        for peer in snapshot.peers where peer.deviceID != localDeviceID && connections[peer.deviceID] == nil {
+            let connection = try peerConnectionFactory.makePeerConnection(peer: peer, iceConfig: iceConfig)
+            connections[peer.deviceID] = connection
+            peerStates[peer.deviceID] = .connecting
+            if shouldCreateInitialOffer(to: peer.deviceID) {
+                let offer = try await connection.makeOffer()
+                try await sendSignal(.signalOffer, targetDeviceID: peer.deviceID, body: ["sdp": .string(offer)])
+            }
+        }
+    }
+
+    public func sendAnswer(_ sdp: String, to targetDeviceID: DeviceID) async throws {
+        try await sendSignal(.signalAnswer, targetDeviceID: targetDeviceID, body: ["sdp": .string(sdp)])
+    }
+
+    public func sendICECandidate(_ candidate: String, to targetDeviceID: DeviceID) async throws {
+        try StrictP2PICEPolicy.validateCandidate(candidate)
+        try await sendSignal(.signalIceCandidate, targetDeviceID: targetDeviceID, body: ["candidate": .string(candidate)])
+    }
+
+    public func setPublishingEnabled(_ enabled: Bool) async throws {
+        for connection in connections.values {
+            try await connection.setPublishingEnabled(enabled)
+        }
+        isPublishing = enabled
+    }
+
+    public func leaveRoom() async {
+        await closeConnections()
+        activeConversationID = nil
+    }
+
+    private func shouldCreateInitialOffer(to peerDeviceID: DeviceID) -> Bool {
+        localDeviceID.rawValue < peerDeviceID.rawValue
+    }
+
+    private func sendSignal(
+        _ type: RealtimeEventType,
+        targetDeviceID: DeviceID,
+        body: [String: JSONValue]
+    ) async throws {
+        guard let activeConversationID else {
+            throw TokiAPIError.invalidResponse
+        }
+
+        var payload = body
+        payload["targetDeviceId"] = .string(targetDeviceID.rawValue)
+        let envelope = AnyRealtimeEventEnvelope(
+            type: type,
+            id: eventID.nextEventID(),
+            conversationID: activeConversationID,
+            sentAt: clock.now(),
+            payload: .object(payload)
+        )
+        try await transport.send(envelope)
+    }
+
+    private func closeConnections() async {
+        if isPublishing {
+            for connection in connections.values {
+                try? await connection.setPublishingEnabled(false)
+            }
+        }
+        for (deviceID, connection) in connections {
+            await connection.close()
+            peerStates[deviceID] = .closed
+        }
+        connections.removeAll()
+        peerStates.removeAll()
+        isPublishing = false
+    }
+}

--- a/Sources/TokiCore/TokiAPIClient.swift
+++ b/Sources/TokiCore/TokiAPIClient.swift
@@ -160,6 +160,17 @@ public final class TokiAPIClient: @unchecked Sendable {
         try await send(path: "/v1/conversations", method: "GET", body: EmptyRequest?.none, sessionToken: sessionToken)
     }
 
+    public func iceConfig(sessionToken: String) async throws -> ICEConfigResponse {
+        let response: ICEConfigResponse = try await send(
+            path: "/v1/ice-config",
+            method: "GET",
+            body: EmptyRequest?.none,
+            sessionToken: sessionToken
+        )
+        try StrictP2PICEPolicy.validate(response)
+        return response
+    }
+
     public func createConversation(
         type: ConversationKind,
         memberIDs: [UserID],

--- a/Tests/TokiCoreTests/AuthAPIClientTests.swift
+++ b/Tests/TokiCoreTests/AuthAPIClientTests.swift
@@ -183,6 +183,31 @@ final class AuthAPIClientTests: XCTestCase {
         XCTAssertEqual(response.conversation.members.first?.user.id, UserID("user-4"))
     }
 
+    func testIceConfigFetchesAuthenticatedStrictP2PConfiguration() async throws {
+        let client = makeClient { request in
+            XCTAssertEqual(request.url?.path, "/v1/ice-config")
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer session-token")
+
+            return Self.jsonResponse(
+                """
+                {
+                  "iceServers": [
+                    { "urls": ["stun:stun.l.google.com:19302"] }
+                  ],
+                  "relayPolicy": "disabled"
+                }
+                """
+            )
+        }
+
+        let response = try await client.iceConfig(sessionToken: "session-token")
+
+        XCTAssertEqual(response.relayPolicy, .disabled)
+        XCTAssertEqual(response.iceServers.flatMap(\.urls), ["stun:stun.l.google.com:19302"])
+        XCTAssertNoThrow(try StrictP2PICEPolicy.validate(response))
+    }
+
     private func makeClient(
         handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)
     ) -> TokiAPIClient {

--- a/Tests/TokiCoreTests/PeerConnectionManagerTests.swift
+++ b/Tests/TokiCoreTests/PeerConnectionManagerTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import TokiCore
+
+final class PeerConnectionManagerTests: XCTestCase {
+    func testRoomSnapshotDecodesServerPayloadKeys() throws {
+        let data = Data(
+            """
+            {
+              "conversationId": "conversation-1",
+              "peers": [
+                {
+                  "connectionId": "connection-a",
+                  "userId": "user-a",
+                  "deviceId": "device-a",
+                  "active": true
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let snapshot = try JSONDecoder().decode(RoomSnapshot.self, from: data)
+
+        XCTAssertEqual(snapshot.conversationID, ConversationID("conversation-1"))
+        XCTAssertEqual(snapshot.peers.first?.connectionID, "connection-a")
+        XCTAssertEqual(snapshot.peers.first?.userID, UserID("user-a"))
+        XCTAssertEqual(snapshot.peers.first?.deviceID, DeviceID("device-a"))
+    }
+
+    func testJoinRoomCreatesPeersAndSmallerLocalDeviceSendsOffers() async throws {
+        let transport = PeerRecordingRealtimeTransport()
+        let factory = RecordingPeerConnectionFactory()
+        let manager = PeerConnectionManager(
+            localDeviceID: DeviceID("device-b"),
+            iceConfig: .stunOnly(urls: ["stun:stun.l.google.com:19302"]),
+            transport: transport,
+            peerConnectionFactory: factory,
+            eventID: IncrementingRealtimeEventID(prefix: "peer"),
+            clock: FixedRealtimeClock(now: Date(timeIntervalSince1970: 1_720_000_000))
+        )
+
+        try await manager.joinRoom(
+            RoomSnapshot(
+                conversationID: ConversationID("conversation-1"),
+                peers: [
+                    RoomPeer(connectionID: "connection-local", userID: UserID("user-local"), deviceID: DeviceID("device-b"), active: true),
+                    RoomPeer(connectionID: "connection-a", userID: UserID("user-a"), deviceID: DeviceID("device-a"), active: true),
+                    RoomPeer(connectionID: "connection-c", userID: UserID("user-c"), deviceID: DeviceID("device-c"), active: true)
+                ]
+            )
+        )
+
+        XCTAssertEqual(factory.createdPeerDeviceIDs, [DeviceID("device-a"), DeviceID("device-c")])
+        XCTAssertEqual(manager.peerStates[DeviceID("device-a")], .connecting)
+        XCTAssertEqual(manager.peerStates[DeviceID("device-c")], .connecting)
+        XCTAssertEqual(transport.sent.map(\.type), [.signalOffer])
+        XCTAssertEqual(transport.sent.first?.conversationID, ConversationID("conversation-1"))
+        XCTAssertEqual(transport.sent.first?.payload.objectValue?["targetDeviceId"], .string("device-c"))
+        XCTAssertEqual(transport.sent.first?.payload.objectValue?["sdp"], .string("offer-for-device-c"))
+    }
+
+    func testSignalsAnswersAndIceCandidatesThroughRealtimeTransport() async throws {
+        let transport = PeerRecordingRealtimeTransport()
+        let manager = PeerConnectionManager(
+            localDeviceID: DeviceID("device-b"),
+            iceConfig: .stunOnly(urls: ["stun:stun.l.google.com:19302"]),
+            transport: transport,
+            peerConnectionFactory: RecordingPeerConnectionFactory(),
+            eventID: IncrementingRealtimeEventID(prefix: "signal"),
+            clock: FixedRealtimeClock(now: Date(timeIntervalSince1970: 1_720_000_000))
+        )
+        try await manager.joinRoom(
+            RoomSnapshot(
+                conversationID: ConversationID("conversation-1"),
+                peers: [RoomPeer(connectionID: "connection-a", userID: UserID("user-a"), deviceID: DeviceID("device-a"), active: true)]
+            )
+        )
+        transport.sent.removeAll()
+
+        try await manager.sendAnswer("answer-sdp", to: DeviceID("device-a"))
+        try await manager.sendICECandidate("candidate:1 1 udp 1 192.0.2.1 5000 typ host", to: DeviceID("device-a"))
+
+        XCTAssertEqual(transport.sent.map(\.type), [.signalAnswer, .signalIceCandidate])
+        XCTAssertEqual(transport.sent.map { $0.payload.objectValue?["targetDeviceId"] }, [.string("device-a"), .string("device-a")])
+        XCTAssertEqual(transport.sent.map { $0.payload.objectValue?["sdp"] }, [.string("answer-sdp"), nil])
+        XCTAssertEqual(transport.sent.map { $0.payload.objectValue?["candidate"] }, [nil, .string("candidate:1 1 udp 1 192.0.2.1 5000 typ host")])
+    }
+
+    func testLeaveRoomClosesConnectionsAndClearsPublishingState() async throws {
+        let factory = RecordingPeerConnectionFactory()
+        let manager = PeerConnectionManager(
+            localDeviceID: DeviceID("device-b"),
+            iceConfig: .stunOnly(urls: ["stun:stun.l.google.com:19302"]),
+            transport: PeerRecordingRealtimeTransport(),
+            peerConnectionFactory: factory,
+            eventID: IncrementingRealtimeEventID(prefix: "peer"),
+            clock: FixedRealtimeClock(now: Date(timeIntervalSince1970: 1_720_000_000))
+        )
+        try await manager.joinRoom(
+            RoomSnapshot(
+                conversationID: ConversationID("conversation-1"),
+                peers: [RoomPeer(connectionID: "connection-c", userID: UserID("user-c"), deviceID: DeviceID("device-c"), active: true)]
+            )
+        )
+
+        try await manager.setPublishingEnabled(true)
+        await manager.leaveRoom()
+
+        XCTAssertEqual(factory.connections.first?.closedCount, 1)
+        XCTAssertEqual(factory.connections.first?.publishingHistory, [true, false])
+        XCTAssertTrue(manager.peerStates.isEmpty)
+        XCTAssertFalse(manager.isPublishing)
+    }
+}
+
+private final class RecordingPeerConnectionFactory: PeerConnectionCreating, @unchecked Sendable {
+    private(set) var connections: [RecordingPeerConnection] = []
+
+    var createdPeerDeviceIDs: [DeviceID] {
+        connections.map(\.peer.deviceID)
+    }
+
+    func makePeerConnection(peer: RoomPeer, iceConfig: ICEConfigResponse) throws -> PeerConnectionControlling {
+        let connection = RecordingPeerConnection(peer: peer)
+        connections.append(connection)
+        return connection
+    }
+}
+
+private final class RecordingPeerConnection: PeerConnectionControlling, @unchecked Sendable {
+    let peer: RoomPeer
+    private(set) var closedCount = 0
+    private(set) var publishingHistory: [Bool] = []
+
+    init(peer: RoomPeer) {
+        self.peer = peer
+    }
+
+    func makeOffer() async throws -> String {
+        "offer-for-\(peer.deviceID.rawValue)"
+    }
+
+    func setPublishingEnabled(_ enabled: Bool) async throws {
+        publishingHistory.append(enabled)
+    }
+
+    func close() async {
+        closedCount += 1
+    }
+}
+
+private final class PeerRecordingRealtimeTransport: RealtimeTransporting, @unchecked Sendable {
+    private(set) var connectedTokens: [String] = []
+    var sent: [AnyRealtimeEventEnvelope] = []
+
+    func connect(sessionToken: String) async throws {
+        connectedTokens.append(sessionToken)
+    }
+
+    func send(_ envelope: AnyRealtimeEventEnvelope) async throws {
+        sent.append(envelope)
+    }
+
+    func close() async {}
+}
+
+private extension JSONValue {
+    var objectValue: [String: JSONValue]? {
+        guard case .object(let value) = self else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Tests/TokiCoreTests/StrictP2PICEPolicyTests.swift
+++ b/Tests/TokiCoreTests/StrictP2PICEPolicyTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import TokiCore
+
+final class StrictP2PICEPolicyTests: XCTestCase {
+    func testAcceptsStunOnlyConfigWithDisabledRelayPolicy() throws {
+        let config = ICEConfigResponse(
+            iceServers: [ICEConfigServer(urls: ["stun:stun.l.google.com:19302"])],
+            relayPolicy: .disabled
+        )
+
+        XCTAssertNoThrow(try StrictP2PICEPolicy.validate(config))
+    }
+
+    func testRejectsTurnUrlsRelayPolicyChangesAndRelayCandidates() {
+        XCTAssertThrowsError(
+            try StrictP2PICEPolicy.validate(
+                ICEConfigResponse(
+                    iceServers: [ICEConfigServer(urls: ["turn:relay.example.com:3478"])],
+                    relayPolicy: .disabled
+                )
+            )
+        )
+
+        XCTAssertThrowsError(
+            try StrictP2PICEPolicy.validate(
+                ICEConfigResponse(
+                    iceServers: [ICEConfigServer(urls: ["stun:stun.l.google.com:19302"])],
+                    relayPolicy: .enabled
+                )
+            )
+        )
+
+        XCTAssertThrowsError(
+            try StrictP2PICEPolicy.validateCandidate(
+                "candidate:842163049 1 udp 1677729535 203.0.113.10 54400 typ relay raddr 0.0.0.0 rport 0"
+            )
+        )
+    }
+}

--- a/docs/engineering/strict-p2p-webrtc-audio.md
+++ b/docs/engineering/strict-p2p-webrtc-audio.md
@@ -1,0 +1,38 @@
+# Strict P2P WebRTC Audio
+
+This phase establishes the enforceable strict-P2P contracts before native media wiring.
+
+## Implemented Contracts
+
+- `GET /v1/ice-config` is authenticated and returns only STUN URLs with `relayPolicy: "disabled"`.
+- Swift client code validates ICE config before use.
+- TURN URLs, relay policy changes, and relay ICE candidates are rejected client-side.
+- `PeerConnectionManager` builds an active-room peer mesh from `room.snapshot`.
+- Device IDs choose the initial offerer deterministically: the lexicographically smaller device ID offers.
+- Offers, answers, and ICE candidates are sent through the existing realtime signaling envelope.
+- Leaving or switching rooms closes all tracked peer connections and disables publishing.
+
+## Not Yet Implemented
+
+- Native WebRTC library integration.
+- Real microphone capture and Opus track publishing.
+- Remote audio track playback through selected output devices.
+- User-facing per-peer diagnostics beyond the existing P2P failure state model.
+- Manual two-client LAN and restrictive-network verification.
+
+## Testing
+
+Automated Swift coverage:
+
+- ICE config validation accepts STUN-only config.
+- ICE config validation rejects TURN URLs, enabled relay policy, and relay candidates.
+- API client fetches `/v1/ice-config` with bearer auth and validates the response.
+- Room snapshots decode the backend JSON keys.
+- Peer manager creates per-peer connections, selects the deterministic offerer, sends signaling envelopes, and closes connections on room leave.
+
+Automated Go coverage:
+
+- Backend `/v1/ice-config` requires a bearer session.
+- Backend ICE config response is STUN-only and has `relayPolicy: "disabled"`.
+
+CI runs both Swift and Go test suites for pull requests. Local Go verification requires Go 1.22 or newer.

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -48,6 +48,15 @@ type presenceResponse struct {
 	ActiveSpeakerID *string  `json:"activeSpeakerId"`
 }
 
+type iceConfigResponse struct {
+	ICEServers  []iceConfigServerResponse `json:"iceServers"`
+	RelayPolicy string                    `json:"relayPolicy"`
+}
+
+type iceConfigServerResponse struct {
+	URLs []string `json:"urls"`
+}
+
 type conversationResponse struct {
 	ID           string                       `json:"id"`
 	Type         string                       `json:"type"`
@@ -70,6 +79,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /v1/auth/magic-link", s.handleMagicLink)
 	s.mux.HandleFunc("POST /v1/auth/session", s.handleSession)
 	s.mux.HandleFunc("GET /v1/me", s.handleMe)
+	s.mux.HandleFunc("GET /v1/ice-config", s.handleIceConfig)
 	s.mux.HandleFunc("GET /v1/realtime", s.realtime.ServeHTTP)
 	s.mux.HandleFunc("GET /v1/conversations", s.handleListConversations)
 	s.mux.HandleFunc("POST /v1/conversations", s.handleCreateConversation)
@@ -121,6 +131,18 @@ func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
 		"user":            apiUser(bundle.User),
 		"teamMemberships": apiMemberships(bundle),
 		"devices":         apiDevices(bundle.Devices),
+	})
+}
+
+func (s *Server) handleIceConfig(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireSession(w, r); !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, iceConfigResponse{
+		ICEServers: []iceConfigServerResponse{
+			{URLs: []string{"stun:stun.l.google.com:19302"}},
+		},
+		RelayPolicy: "disabled",
 	})
 }
 

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"toki/internal/httpapi"
@@ -147,6 +148,36 @@ func TestGroupConversationMaximumTenParticipants(t *testing.T) {
 
 	if res := postJSON(t, srv, "/v1/conversations/"+group.ID+"/members", map[string]any{"memberIds": []string{memberIDs[9]}}, alice.Token); res.Code != http.StatusBadRequest {
 		t.Fatalf("adding eleventh group member status = %d, want %d", res.Code, http.StatusBadRequest)
+	}
+}
+
+func TestIceConfigRequiresSessionAndReturnsStunOnlyRelayDisabled(t *testing.T) {
+	srv := newTestServer(t, "alice@example.com")
+
+	if res := get(t, srv, "/v1/ice-config", ""); res.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated ice config status = %d, want %d", res.Code, http.StatusUnauthorized)
+	}
+
+	alice := signIn(t, srv, "alice@example.com")
+	iceConfig := decodeResponse[struct {
+		RelayPolicy string `json:"relayPolicy"`
+		ICEServers  []struct {
+			URLs []string `json:"urls"`
+		} `json:"iceServers"`
+	}](t, get(t, srv, "/v1/ice-config", alice.Token))
+
+	if iceConfig.RelayPolicy != "disabled" {
+		t.Fatalf("relay policy = %q, want disabled", iceConfig.RelayPolicy)
+	}
+	if len(iceConfig.ICEServers) == 0 {
+		t.Fatal("ice config has no STUN servers")
+	}
+	for _, server := range iceConfig.ICEServers {
+		for _, url := range server.URLs {
+			if !strings.HasPrefix(url, "stun:") {
+				t.Fatalf("ice server url = %q, want STUN-only", url)
+			}
+		}
 	}
 }
 

--- a/plans/04-strict-p2p-webrtc-audio.md
+++ b/plans/04-strict-p2p-webrtc-audio.md
@@ -63,3 +63,22 @@
 - Manual test two Macs or two local clients on the same LAN.
 - Manual failure test on a restrictive network or with blocked UDP to verify user-facing P2P failure state.
 - Inspect backend request logs and WebSocket handlers to confirm no raw audio path exists.
+
+## Implementation Status
+
+Completed in `codex-strict-p2p-webrtc-audio-foundation`:
+
+- Authenticated `GET /v1/ice-config` returning STUN-only URLs and `relayPolicy: "disabled"`.
+- Swift strict ICE policy validation for TURN URLs, relay policy changes, and relay candidates.
+- Client API integration for fetching and validating ICE config.
+- Protocol-backed `PeerConnectionManager` for active-room peer tracking, deterministic offer selection, signaling envelope forwarding, publishing toggles, and room cleanup.
+- Automated Swift tests for strict ICE validation, client fetch/validation, room snapshot decoding, peer mesh setup, signaling, and cleanup.
+- Automated Go test coverage for the backend ICE config endpoint.
+
+Remaining for the next implementation pass:
+
+- Select and integrate the native WebRTC dependency.
+- Create real peer connections from `PeerConnectionManager`.
+- Attach microphone tracks only from the floor-controlled PTT flow.
+- Receive remote audio tracks and route them to selected output devices.
+- Complete two-client LAN and restrictive-network manual verification.


### PR DESCRIPTION
## Summary

- Add an authenticated `/v1/ice-config` endpoint that returns STUN-only ICE config with relay disabled.
- Add Swift strict P2P ICE validation and authenticated client fetching for ICE config.
- Add a protocol-backed `PeerConnectionManager` for active-room peer mesh setup, deterministic offerer selection, signaling envelopes, publishing toggles, and room cleanup.
- Update README, phase plan status, and engineering docs for the implemented foundation and remaining native WebRTC/audio work.

## Testing

- `rtk swift build`
- `rtk swift test`
- `rtk ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'ok'"`

Local Go verification was not run because this environment has no `go` binary. CI is configured to run `go test ./...`, and this PR adds backend coverage for `/v1/ice-config`.