### PR TITLE
[codex] Implement PTT floor control

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The media policy is strict peer-to-peer for the MVP. The backend may coordinate 
 - Storage: PostgreSQL metadata migration in `migrations/001_metadata.sql`; current backend tests use an in-memory store.
 - Auth: invited-email development magic-link flow, bearer session token, client-side Keychain token storage.
 - Conversations: signed-in users can list conversations, create direct/group conversations, and add group members.
-- Realtime: authenticated `/v1/realtime` WebSocket for active-room presence and WebRTC signaling metadata.
+- Realtime: authenticated `/v1/realtime` WebSocket for active-room presence, WebRTC signaling metadata, and one-speaker floor control.
+- PTT floor control: backend grants one ephemeral floor token per conversation, denies concurrent speakers, and clears held floors on release, disconnect, timeout, or backend restart.
 - Strict P2P media foundation: authenticated STUN-only ICE config, client-side TURN/relay rejection, and a protocol-backed peer connection manager for active-room mesh setup.
 
 ## Product Constraints
@@ -100,11 +101,21 @@ Realtime messages use a JSON envelope:
 }
 ```
 
-Client event types are `room.join`, `room.leave`, `presence.set`, `signal.offer`, `signal.answer`, and `signal.iceCandidate`.
+Client event types are `room.join`, `room.leave`, `presence.set`, `signal.offer`, `signal.answer`, `signal.iceCandidate`, `floor.request`, and `floor.release`.
 
-Server event types are `room.snapshot`, `presence.updated`, `signal.forwarded`, `error`, and `reconnect.required`.
+Server event types are `room.snapshot`, `presence.updated`, `signal.forwarded`, `floor.granted`, `floor.denied`, `floor.released`, `floor.changed`, `error`, and `reconnect.required`.
+
+Floor-control payloads:
+
+- `floor.request`: `{ "conversationId": "...", "deviceId": "..." }`
+- `floor.granted`: `{ "conversationId": "...", "tokenId": "...", "speakerUserId": "...", "speakerDeviceId": "...", "grantedAt": "..." }`
+- `floor.denied`: `{ "conversationId": "...", "reason": "busy" }`
+- `floor.release`: `{ "conversationId": "...", "tokenId": "..." }`
+- `floor.released`: `{ "conversationId": "...", "tokenId": "...", "reason": "released|disconnect|timeout|server_reset" }`
 
 The WebSocket carries presence, room membership, and WebRTC signaling bodies only. It must not carry raw audio frames. Signaling is forwarded only between devices currently joined to the same authorized conversation. The client rejects ICE configs with TURN URLs, non-disabled relay policy, or relay ICE candidates.
+
+PTT press requests the floor but does not enable microphone publishing. Publishing is allowed only after `floor.granted` gives the local user a token, and release/reconnect/timeout paths stop local publishing before or regardless of whether the backend receives the release.
 
 ## Strict P2P WebRTC Status
 
@@ -114,6 +125,7 @@ Implemented in the current foundation:
 - `TokiAPIClient.iceConfig(sessionToken:)` validates the response before returning it to app code.
 - `StrictP2PICEPolicy` rejects TURN URLs, relay policy changes, and relay ICE candidates.
 - `PeerConnectionManager` creates peer connections from `room.snapshot`, uses lexicographic device IDs for deterministic offerer selection, forwards offer/answer/candidate signaling over the realtime transport, and closes all peer connections when leaving or switching rooms.
+- `AppSessionState` gates local microphone publishing on a valid local floor token, and `PeerConnectionManager.applyFloor` enables peer publishing only for a local grant.
 
 Still intentionally pending until the native WebRTC dependency is selected and wired:
 
@@ -126,4 +138,4 @@ Still intentionally pending until the native WebRTC dependency is selected and w
 
 The backend realtime channel intentionally avoids audio paths. Re-check this before merging any future WebRTC, replay, diagnostics, or observability changes.
 
-CI runs the full Swift package tests and Go backend tests on pull requests. The phase-04 automated coverage includes strict ICE validation, authenticated ICE config fetching, peer mesh lifecycle/signaling behavior, and the backend ICE config endpoint. Local Go verification requires Go 1.22 or newer to be installed.
+CI runs the full Swift package tests and Go backend tests on pull requests. The current automated coverage includes strict ICE validation, authenticated ICE config fetching, peer mesh lifecycle/signaling behavior, token-aware PTT floor state, realtime floor request/release encoding, backend floor grant/deny/release/disconnect/timeout behavior, and the backend ICE config endpoint. Local Go verification requires Go 1.22 or newer to be installed.

--- a/Sources/TokiApp/AppShellModel.swift
+++ b/Sources/TokiApp/AppShellModel.swift
@@ -131,6 +131,7 @@ final class AppShellModel: ObservableObject {
     @Published private(set) var menuBarStatus: MenuBarStatus = .signedOut
     @Published private(set) var activityLabel = "Signed out"
     @Published private(set) var detailStatus = "Select a room to listen."
+    @Published private(set) var activeSpeakerLabel: String?
     @Published private(set) var canUseManualPTT = false
     @Published private(set) var canUseKeyboardPTT = false
     @Published private(set) var rooms: [RoomSummary] = []
@@ -213,6 +214,7 @@ final class AppShellModel: ObservableObject {
         menuBarStatus = .signedOut
         activityLabel = "Signed out"
         detailStatus = "Open Toki to join a room."
+        activeSpeakerLabel = nil
         canUseManualPTT = false
         canUseKeyboardPTT = false
     }
@@ -298,7 +300,7 @@ final class AppShellModel: ObservableObject {
 
     func simulateRemoteSpeaker() {
         guard let session else { return }
-        session.floorGrantReceived(speakerID: UserID("teammate"))
+        session.floorGrantReceived(tokenID: FloorTokenID("simulated-remote-floor"), speakerID: UserID("teammate"))
         syncFromSession()
     }
 
@@ -369,7 +371,7 @@ final class AppShellModel: ObservableObject {
                 return
             }
 
-            self.session?.floorGrantReceived(speakerID: session.localUserID)
+            self.session?.floorGrantReceived(tokenID: FloorTokenID("simulated-local-floor"), speakerID: session.localUserID)
             self.syncFromSession()
         }
     }
@@ -381,6 +383,7 @@ final class AppShellModel: ObservableObject {
         canUseKeyboardPTT = session.canStartPushToTalk(source: .keyboard)
         menuBarStatus = resolveMenuBarStatus(session: session)
         activityLabel = resolveActivityLabel(session: session)
+        activeSpeakerLabel = resolveActiveSpeakerLabel(session: session)
         detailStatus = resolveDetailStatus(session: session)
     }
 
@@ -449,7 +452,11 @@ final class AppShellModel: ObservableObject {
         case .speaking:
             "PTT is held. Release to stop transmitting."
         case .floorBusy:
-            "Another teammate has the floor."
+            if let activeSpeakerLabel {
+                "\(activeSpeakerLabel) has the floor."
+            } else {
+                "Another teammate has the floor."
+            }
         case .reconnecting:
             "Realtime link dropped. Rejoin the room when connected."
         case .p2pUnavailable:
@@ -460,6 +467,15 @@ final class AppShellModel: ObservableObject {
             "Global shortcut access is unavailable. Manual PTT still works."
         @unknown default:
             "Connected."
+        }
+    }
+
+    private func resolveActiveSpeakerLabel(session: AppSessionState) -> String? {
+        switch session.floor {
+        case .granted(let speakerID, _), .busy(let speakerID):
+            speakerID == currentUserID ? "You" : speakerID.rawValue
+        case .idle, .requesting, .blocked:
+            nil
         }
     }
 

--- a/Sources/TokiApp/AppShellView.swift
+++ b/Sources/TokiApp/AppShellView.swift
@@ -162,6 +162,7 @@ private struct ActiveRoomPanel: View {
             HStack(spacing: 12) {
                 SummaryMetric(title: "Participants", value: "\(model.selectedRoom?.participants ?? 0)")
                 SummaryMetric(title: "Output", value: model.isOutputMuted ? "Muted" : "Live")
+                SummaryMetric(title: "Speaker", value: model.activeSpeakerLabel ?? "None")
                 SummaryMetric(title: "Shortcut", value: model.canUseKeyboardPTT ? "Ready" : "Blocked")
             }
 
@@ -196,6 +197,11 @@ private struct StatusStrip: View {
             Text(model.detailStatus)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
+            if let activeSpeakerLabel = model.activeSpeakerLabel {
+                Text("Speaker: \(activeSpeakerLabel)")
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
             Spacer()
             Text(model.pushToTalkShortcutLabel)
                 .foregroundStyle(.secondary)

--- a/Sources/TokiApp/MenuBarController.swift
+++ b/Sources/TokiApp/MenuBarController.swift
@@ -36,6 +36,9 @@ final class MenuBarController {
 
         let menu = NSMenu()
         menu.addItem(NSMenuItem(title: model.activityLabel, action: nil, keyEquivalent: ""))
+        if let activeSpeakerLabel = model.activeSpeakerLabel {
+            menu.addItem(NSMenuItem(title: "Speaker: \(activeSpeakerLabel)", action: nil, keyEquivalent: ""))
+        }
         menu.addItem(.separator())
 
         let openItem = NSMenuItem(title: "Open Toki", action: #selector(openToki), keyEquivalent: "")

--- a/Sources/TokiCore/AppSessionState.swift
+++ b/Sources/TokiCore/AppSessionState.swift
@@ -22,7 +22,7 @@ public enum FloorBlockReason: Equatable, Sendable {
 public enum FloorState: Equatable, Sendable {
     case idle
     case requesting(localUserID: UserID)
-    case granted(speakerID: UserID)
+    case granted(speakerID: UserID, tokenID: FloorTokenID)
     case busy(speakerID: UserID)
     case blocked(reason: FloorBlockReason)
 }
@@ -57,6 +57,8 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
     @Published public private(set) var floor: FloorState
     @Published public private(set) var activity: SessionActivity
     @Published public private(set) var devicePreferences: DevicePreferences
+    @Published public private(set) var shouldPublishMicrophone = false
+    @Published public private(set) var lastReleasedFloorTokenID: FloorTokenID?
 
     private let permissions: PermissionCoordinating
     private var isPushToTalkActive = false
@@ -159,23 +161,52 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
         }
 
         isPushToTalkActive = true
+        shouldPublishMicrophone = false
+        lastReleasedFloorTokenID = nil
         floor = .requesting(localUserID: localUserID)
         activity = .requestingFloor
     }
 
-    public func floorGrantReceived(speakerID: UserID) {
+    public func floorGrantReceived(tokenID: FloorTokenID, speakerID: UserID) {
         if speakerID == localUserID && isPushToTalkActive {
-            floor = .granted(speakerID: speakerID)
+            floor = .granted(speakerID: speakerID, tokenID: tokenID)
             activity = .speaking
+            shouldPublishMicrophone = true
             return
         }
 
+        shouldPublishMicrophone = false
         floor = .busy(speakerID: speakerID)
         activity = .floorBusy
     }
 
+    public func floorDeniedReceived(reason: FloorDeniedReason, speakerID: UserID? = nil) {
+        isPushToTalkActive = false
+        shouldPublishMicrophone = false
+        switch reason {
+        case .busy:
+            floor = .busy(speakerID: speakerID ?? localUserID)
+            activity = .floorBusy
+        case .notJoined, .forbidden:
+            floor = .idle
+            activity = activeConversationID == nil ? .idle : .listening
+        }
+    }
+
+    public func floorReleasedReceived(tokenID: FloorTokenID, reason: FloorReleasedReason) {
+        _ = tokenID
+        _ = reason
+        shouldPublishMicrophone = false
+        floor = .idle
+        activity = activeConversationID == nil ? .idle : .listening
+    }
+
     public func pushToTalkReleased() {
         isPushToTalkActive = false
+        if case .granted(let speakerID, let tokenID) = floor, speakerID == localUserID {
+            lastReleasedFloorTokenID = tokenID
+        }
+        shouldPublishMicrophone = false
 
         guard activeConversationID != nil else {
             floor = .idle
@@ -192,14 +223,21 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
 
         switch state {
         case .disconnected:
+            shouldPublishMicrophone = false
+            floor = .idle
             activity = .idle
         case .connected:
+            shouldPublishMicrophone = false
             activity = .connected
         case .listening:
             activity = activeConversationID == nil ? .idle : .listening
         case .reconnecting:
+            shouldPublishMicrophone = false
+            floor = .idle
             activity = .reconnecting
         case .p2pUnavailable:
+            shouldPublishMicrophone = false
+            floor = .idle
             activity = .p2pUnavailable
         }
     }

--- a/Sources/TokiCore/Identifiers.swift
+++ b/Sources/TokiCore/Identifiers.swift
@@ -48,6 +48,18 @@ public struct DeviceID: RawRepresentable, Hashable, Codable, Sendable {
     }
 }
 
+public struct FloorTokenID: RawRepresentable, Hashable, Codable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: String) {
+        self.init(rawValue: rawValue)
+    }
+}
+
 public struct MembershipID: RawRepresentable, Hashable, Codable, Sendable {
     public let rawValue: String
 

--- a/Sources/TokiCore/PeerConnectionManager.swift
+++ b/Sources/TokiCore/PeerConnectionManager.swift
@@ -117,6 +117,16 @@ public final class PeerConnectionManager<EventID: RealtimeEventIDGenerating>: @u
         isPublishing = enabled
     }
 
+    public func applyFloor(_ floor: FloorState, localUserID: UserID) async throws {
+        let enabled: Bool
+        if case .granted(let speakerID, _) = floor, speakerID == localUserID {
+            enabled = true
+        } else {
+            enabled = false
+        }
+        try await setPublishingEnabled(enabled)
+    }
+
     public func leaveRoom() async {
         await closeConnections()
         activeConversationID = nil

--- a/Sources/TokiCore/RealtimeConnectionManager.swift
+++ b/Sources/TokiCore/RealtimeConnectionManager.swift
@@ -172,6 +172,30 @@ public final class RealtimeConnectionManager<EventID: RealtimeEventIDGenerating>
         state = .listening(conversationID: conversationID)
     }
 
+    public func requestFloor(conversationID: ConversationID, deviceID: DeviceID) async throws {
+        let payload = FloorRequestPayload(conversationID: conversationID, deviceID: deviceID)
+        let envelope = RealtimeEventEnvelope(
+            type: .floorRequest,
+            id: eventID.nextEventID(),
+            conversationID: conversationID,
+            sentAt: clock.now(),
+            payload: payload
+        )
+        try await transport.send(AnyRealtimeEventEnvelope(envelope))
+    }
+
+    public func releaseFloor(conversationID: ConversationID, tokenID: FloorTokenID) async throws {
+        let payload = FloorReleasePayload(conversationID: conversationID, tokenID: tokenID)
+        let envelope = RealtimeEventEnvelope(
+            type: .floorRelease,
+            id: eventID.nextEventID(),
+            conversationID: conversationID,
+            sentAt: clock.now(),
+            payload: payload
+        )
+        try await transport.send(AnyRealtimeEventEnvelope(envelope))
+    }
+
     public func handleConnectionDropped() async {
         reconnectAttempt += 1
         state = .reconnecting(attempt: reconnectAttempt)

--- a/Sources/TokiCore/RealtimeEvent.swift
+++ b/Sources/TokiCore/RealtimeEvent.swift
@@ -10,6 +10,12 @@ public enum RealtimeEventType: String, Codable, Equatable, Sendable {
     case signalAnswer = "signal.answer"
     case signalIceCandidate = "signal.iceCandidate"
     case signalForwarded = "signal.forwarded"
+    case floorRequest = "floor.request"
+    case floorGranted = "floor.granted"
+    case floorDenied = "floor.denied"
+    case floorRelease = "floor.release"
+    case floorReleased = "floor.released"
+    case floorChanged = "floor.changed"
     case error
     case reconnectRequired = "reconnect.required"
 }
@@ -52,6 +58,123 @@ public struct RoomJoinPayload: Codable, Equatable, Sendable {
     }
 }
 
+public struct FloorRequestPayload: Codable, Equatable, Sendable {
+    public let conversationID: ConversationID
+    public let deviceID: DeviceID
+
+    public init(conversationID: ConversationID, deviceID: DeviceID) {
+        self.conversationID = conversationID
+        self.deviceID = deviceID
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case conversationID = "conversationId"
+        case deviceID = "deviceId"
+    }
+}
+
+public struct FloorGrantedPayload: Codable, Equatable, Sendable {
+    public let conversationID: ConversationID
+    public let tokenID: FloorTokenID
+    public let speakerUserID: UserID
+    public let speakerDeviceID: DeviceID
+    public let grantedAt: Date
+
+    public init(
+        conversationID: ConversationID,
+        tokenID: FloorTokenID,
+        speakerUserID: UserID,
+        speakerDeviceID: DeviceID,
+        grantedAt: Date
+    ) {
+        self.conversationID = conversationID
+        self.tokenID = tokenID
+        self.speakerUserID = speakerUserID
+        self.speakerDeviceID = speakerDeviceID
+        self.grantedAt = grantedAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case conversationID = "conversationId"
+        case tokenID = "tokenId"
+        case speakerUserID = "speakerUserId"
+        case speakerDeviceID = "speakerDeviceId"
+        case grantedAt
+    }
+}
+
+public enum FloorDeniedReason: String, Codable, Equatable, Sendable {
+    case busy
+    case notJoined = "not_joined"
+    case forbidden
+}
+
+public struct FloorDeniedPayload: Codable, Equatable, Sendable {
+    public let conversationID: ConversationID
+    public let reason: FloorDeniedReason
+    public let speakerUserID: UserID?
+    public let speakerDeviceID: DeviceID?
+
+    public init(
+        conversationID: ConversationID,
+        reason: FloorDeniedReason,
+        speakerUserID: UserID? = nil,
+        speakerDeviceID: DeviceID? = nil
+    ) {
+        self.conversationID = conversationID
+        self.reason = reason
+        self.speakerUserID = speakerUserID
+        self.speakerDeviceID = speakerDeviceID
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case conversationID = "conversationId"
+        case reason
+        case speakerUserID = "speakerUserId"
+        case speakerDeviceID = "speakerDeviceId"
+    }
+}
+
+public struct FloorReleasePayload: Codable, Equatable, Sendable {
+    public let conversationID: ConversationID
+    public let tokenID: FloorTokenID
+
+    public init(conversationID: ConversationID, tokenID: FloorTokenID) {
+        self.conversationID = conversationID
+        self.tokenID = tokenID
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case conversationID = "conversationId"
+        case tokenID = "tokenId"
+    }
+}
+
+public enum FloorReleasedReason: String, Codable, Equatable, Sendable {
+    case released
+    case disconnect
+    case timeout
+    case serverReset = "server_reset"
+}
+
+public struct FloorReleasedPayload: Codable, Equatable, Sendable {
+    public let conversationID: ConversationID
+    public let tokenID: FloorTokenID
+    public let reason: FloorReleasedReason
+
+    public init(conversationID: ConversationID, tokenID: FloorTokenID, reason: FloorReleasedReason) {
+        self.conversationID = conversationID
+        self.tokenID = tokenID
+        self.reason = reason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case conversationID = "conversationId"
+        case tokenID = "tokenId"
+        case reason
+    }
+}
+
 public struct AnyRealtimeEventEnvelope: Codable, Equatable, Sendable {
     public let type: RealtimeEventType
     public let id: String
@@ -80,6 +203,32 @@ public struct AnyRealtimeEventEnvelope: Codable, Equatable, Sendable {
             conversationID: envelope.conversationID,
             sentAt: envelope.sentAt,
             payload: .object(["active": .bool(envelope.payload.active)])
+        )
+    }
+
+    public init(_ envelope: RealtimeEventEnvelope<FloorRequestPayload>) {
+        self.init(
+            type: envelope.type,
+            id: envelope.id,
+            conversationID: envelope.conversationID,
+            sentAt: envelope.sentAt,
+            payload: .object([
+                "conversationId": .string(envelope.payload.conversationID.rawValue),
+                "deviceId": .string(envelope.payload.deviceID.rawValue)
+            ])
+        )
+    }
+
+    public init(_ envelope: RealtimeEventEnvelope<FloorReleasePayload>) {
+        self.init(
+            type: envelope.type,
+            id: envelope.id,
+            conversationID: envelope.conversationID,
+            sentAt: envelope.sentAt,
+            payload: .object([
+                "conversationId": .string(envelope.payload.conversationID.rawValue),
+                "tokenId": .string(envelope.payload.tokenID.rawValue)
+            ])
         )
     }
 

--- a/Tests/TokiAppTests/AppShellSmokeTests.swift
+++ b/Tests/TokiAppTests/AppShellSmokeTests.swift
@@ -77,6 +77,8 @@ final class AppShellSmokeTests: XCTestCase {
         model.stopPushToTalk()
         model.simulateRemoteSpeaker()
         XCTAssertEqual(model.menuBarStatus, .floorBusy)
+        XCTAssertEqual(model.activeSpeakerLabel, "teammate")
+        XCTAssertEqual(model.detailStatus, "teammate has the floor.")
 
         model.permissionPreset = .microphoneDenied
         model.startManualPushToTalk()

--- a/Tests/TokiCoreTests/AppSessionStateTests.swift
+++ b/Tests/TokiCoreTests/AppSessionStateTests.swift
@@ -46,16 +46,53 @@ final class AppSessionStateTests: XCTestCase {
 
         XCTAssertEqual(session.floor, .requesting(localUserID: session.localUserID))
         XCTAssertEqual(session.activity, .requestingFloor)
+        XCTAssertFalse(session.shouldPublishMicrophone)
 
-        session.floorGrantReceived(speakerID: session.localUserID)
+        session.floorGrantReceived(tokenID: FloorTokenID("floor-1"), speakerID: session.localUserID)
 
-        XCTAssertEqual(session.floor, .granted(speakerID: session.localUserID))
+        XCTAssertEqual(session.floor, .granted(speakerID: session.localUserID, tokenID: FloorTokenID("floor-1")))
         XCTAssertEqual(session.activity, .speaking)
+        XCTAssertTrue(session.shouldPublishMicrophone)
 
         session.pushToTalkReleased()
 
         XCTAssertEqual(session.floor, .idle)
         XCTAssertEqual(session.activity, .listening)
+        XCTAssertFalse(session.shouldPublishMicrophone)
+        XCTAssertEqual(session.lastReleasedFloorTokenID, FloorTokenID("floor-1"))
+    }
+
+    func testFloorDeniedReleasedAndReconnectStopPublishingFailClosed() {
+        let session = AppSessionState.mockSignedIn()
+        session.selectConversation(id: ConversationID("ops"))
+
+        session.pushToTalkPressed(source: .mouse)
+        session.floorDeniedReceived(reason: .busy, speakerID: UserID("teammate"))
+
+        XCTAssertEqual(session.floor, .busy(speakerID: UserID("teammate")))
+        XCTAssertEqual(session.activity, .floorBusy)
+        XCTAssertFalse(session.shouldPublishMicrophone)
+
+        session.floorGrantReceived(tokenID: FloorTokenID("floor-2"), speakerID: session.localUserID)
+        XCTAssertFalse(session.shouldPublishMicrophone)
+
+        session.pushToTalkReleased()
+        session.pushToTalkPressed(source: .mouse)
+        session.floorGrantReceived(tokenID: FloorTokenID("floor-3"), speakerID: session.localUserID)
+        XCTAssertTrue(session.shouldPublishMicrophone)
+
+        session.floorReleasedReceived(tokenID: FloorTokenID("floor-3"), reason: .timeout)
+
+        XCTAssertEqual(session.floor, .idle)
+        XCTAssertEqual(session.activity, .listening)
+        XCTAssertFalse(session.shouldPublishMicrophone)
+
+        session.pushToTalkPressed(source: .mouse)
+        session.floorGrantReceived(tokenID: FloorTokenID("floor-4"), speakerID: session.localUserID)
+        session.connectionChanged(.reconnecting)
+
+        XCTAssertFalse(session.shouldPublishMicrophone)
+        XCTAssertEqual(session.activity, .reconnecting)
     }
 
     func testDeniedMicrophoneFailsClosedAndDisablesPTT() {
@@ -92,7 +129,7 @@ final class AppSessionStateTests: XCTestCase {
         let session = AppSessionState.mockSignedIn()
         session.selectConversation(id: ConversationID("design"))
 
-        session.floorGrantReceived(speakerID: UserID("teammate"))
+        session.floorGrantReceived(tokenID: FloorTokenID("floor-remote"), speakerID: UserID("teammate"))
 
         XCTAssertEqual(session.floor, .busy(speakerID: UserID("teammate")))
         XCTAssertEqual(session.activity, .floorBusy)
@@ -113,7 +150,7 @@ final class AppSessionStateTests: XCTestCase {
         XCTAssertEqual(session.activity, .p2pUnavailable)
 
         session.connectionChanged(.listening)
-        session.floorGrantReceived(speakerID: UserID("teammate"))
+        session.floorGrantReceived(tokenID: FloorTokenID("floor-remote"), speakerID: UserID("teammate"))
         XCTAssertFalse(session.canStartPushToTalk(source: .mouse))
         session.pushToTalkPressed(source: .mouse)
         XCTAssertEqual(session.activity, .floorBusy)

--- a/Tests/TokiCoreTests/PeerConnectionManagerTests.swift
+++ b/Tests/TokiCoreTests/PeerConnectionManagerTests.swift
@@ -111,6 +111,32 @@ final class PeerConnectionManagerTests: XCTestCase {
         XCTAssertTrue(manager.peerStates.isEmpty)
         XCTAssertFalse(manager.isPublishing)
     }
+
+    func testPublishingFollowsOnlyLocalGrantedFloor() async throws {
+        let factory = RecordingPeerConnectionFactory()
+        let manager = PeerConnectionManager(
+            localDeviceID: DeviceID("device-b"),
+            iceConfig: .stunOnly(urls: ["stun:stun.l.google.com:19302"]),
+            transport: PeerRecordingRealtimeTransport(),
+            peerConnectionFactory: factory,
+            eventID: IncrementingRealtimeEventID(prefix: "peer"),
+            clock: FixedRealtimeClock(now: Date(timeIntervalSince1970: 1_720_000_000))
+        )
+        try await manager.joinRoom(
+            RoomSnapshot(
+                conversationID: ConversationID("conversation-1"),
+                peers: [RoomPeer(connectionID: "connection-c", userID: UserID("user-c"), deviceID: DeviceID("device-c"), active: true)]
+            )
+        )
+
+        try await manager.applyFloor(.requesting(localUserID: UserID("user-local")), localUserID: UserID("user-local"))
+        try await manager.applyFloor(.busy(speakerID: UserID("user-c")), localUserID: UserID("user-local"))
+        try await manager.applyFloor(.granted(speakerID: UserID("user-local"), tokenID: FloorTokenID("floor-local")), localUserID: UserID("user-local"))
+        try await manager.applyFloor(.idle, localUserID: UserID("user-local"))
+
+        XCTAssertEqual(factory.connections.first?.publishingHistory, [false, false, true, false])
+        XCTAssertFalse(manager.isPublishing)
+    }
 }
 
 private final class RecordingPeerConnectionFactory: PeerConnectionCreating, @unchecked Sendable {

--- a/Tests/TokiCoreTests/RealtimeConnectionManagerTests.swift
+++ b/Tests/TokiCoreTests/RealtimeConnectionManagerTests.swift
@@ -21,6 +21,47 @@ final class RealtimeConnectionManagerTests: XCTestCase {
         XCTAssertEqual((object["payload"] as? [String: Any])?["active"] as? Bool, true)
     }
 
+    func testFloorRequestAndReleaseEventsCarryDeviceAndTokenIDs() async throws {
+        let transport = RecordingRealtimeTransport()
+        let manager = RealtimeConnectionManager(
+            sessionToken: "session-token",
+            transport: transport,
+            eventID: IncrementingRealtimeEventID(prefix: "floor"),
+            clock: FixedRealtimeClock(now: Date(timeIntervalSince1970: 1_720_000_000))
+        )
+
+        try await manager.requestFloor(conversationID: ConversationID("conversation-1"), deviceID: DeviceID("device-a"))
+        try await manager.releaseFloor(conversationID: ConversationID("conversation-1"), tokenID: FloorTokenID("token-a"))
+
+        XCTAssertEqual(transport.sent.map(\.type), [.floorRequest, .floorRelease])
+        XCTAssertEqual(transport.sent.map(\.conversationID), [ConversationID("conversation-1"), ConversationID("conversation-1")])
+        XCTAssertEqual(transport.sent[0].payload.objectValue?["conversationId"], .string("conversation-1"))
+        XCTAssertEqual(transport.sent[0].payload.objectValue?["deviceId"], .string("device-a"))
+        XCTAssertEqual(transport.sent[1].payload.objectValue?["conversationId"], .string("conversation-1"))
+        XCTAssertEqual(transport.sent[1].payload.objectValue?["tokenId"], .string("token-a"))
+    }
+
+    func testFloorGrantPayloadDecodesServerFields() throws {
+        let data = Data(
+            """
+            {
+              "conversationId": "conversation-1",
+              "tokenId": "token-a",
+              "speakerUserId": "user-a",
+              "speakerDeviceId": "device-a",
+              "grantedAt": "2026-07-06T10:00:00Z"
+            }
+            """.utf8
+        )
+
+        let payload = try JSONDecoder.tokiRealtime.decode(FloorGrantedPayload.self, from: data)
+
+        XCTAssertEqual(payload.conversationID, ConversationID("conversation-1"))
+        XCTAssertEqual(payload.tokenID, FloorTokenID("token-a"))
+        XCTAssertEqual(payload.speakerUserID, UserID("user-a"))
+        XCTAssertEqual(payload.speakerDeviceID, DeviceID("device-a"))
+    }
+
     func testReconnectReauthenticatesRejoinsActiveRoomAndRequestsPeerRenegotiation() async throws {
         let transport = RecordingRealtimeTransport()
         let manager = RealtimeConnectionManager(
@@ -63,6 +104,15 @@ final class RealtimeConnectionManagerTests: XCTestCase {
         await manager.handleConnectionDropped()
         await manager.handleConnectionDropped()
         XCTAssertEqual(manager.nextReconnectDelay(), .seconds(8))
+    }
+}
+
+private extension JSONValue {
+    var objectValue: [String: JSONValue]? {
+        guard case .object(let value) = self else {
+            return nil
+        }
+        return value
     }
 }
 

--- a/docs/engineering/ptt-floor-control.md
+++ b/docs/engineering/ptt-floor-control.md
@@ -1,0 +1,61 @@
+# PTT Floor Control
+
+This phase wires hold-to-talk intent to an ephemeral backend floor token. The backend coordinates who may speak; user audio remains strict peer-to-peer and never crosses the backend.
+
+## Runtime Contract
+
+- A client must be joined to the active room before sending `floor.request`.
+- The request payload includes the active conversation ID and the authenticated device ID.
+- The backend grants only one floor token per conversation.
+- A busy floor returns `floor.denied` with reason `busy` and the current speaker identity when available.
+- `floor.release` must include the current token ID and come from the socket that owns the floor.
+- Floor tokens are sent to the grantee, not to listeners in `floor.changed` or room snapshot state.
+- Held floors are cleared on explicit release, speaking socket disconnect, room leave, timeout, or backend restart.
+- The maximum continuous hold duration is 5 minutes.
+
+## Client Publishing Gate
+
+The client enters requesting state on PTT press and sends `floor.request`, but microphone publishing stays disabled. Publishing is enabled only when the local user receives `floor.granted` while PTT is still held. `PeerConnectionManager.applyFloor` maps that state into peer publishing, enabling media only for a local granted floor and disabling it for requesting, busy, idle, blocked, or remote-speaker states.
+
+Release and failure paths fail closed:
+
+- PTT release immediately disables local publishing before sending `floor.release`.
+- Denial leaves publishing disabled.
+- Reconnect, P2P unavailable, disconnect, timeout, and remote release events clear publishing state.
+- If the release message cannot reach the backend, local publishing remains stopped and the backend clears the stale token by disconnect cleanup or timeout.
+
+## Realtime Events
+
+Client events:
+
+- `floor.request`
+- `floor.release`
+
+Server events:
+
+- `floor.granted`
+- `floor.denied`
+- `floor.released`
+- `floor.changed`
+
+`floor.changed` informs listeners when another device becomes the active speaker. `floor.released` tells all joined clients why the floor cleared: `released`, `disconnect`, `timeout`, or `server_reset`.
+
+## Testing
+
+Automated Swift coverage verifies:
+
+- PTT press requests floor without enabling publishing.
+- Local publishing starts only after a local token grant.
+- Peer publishing follows only a local granted floor.
+- Release, denial, timeout, reconnect, and P2P failure states stop publishing.
+- Floor request and release events encode conversation, device, and token IDs.
+- Server floor grant payloads decode with token and speaker identity.
+
+Automated Go coverage verifies:
+
+- The floor registry grants the first requester and denies concurrent speakers.
+- Wrong-token release attempts do not clear the floor.
+- Explicit release allows a later requester to speak.
+- Disconnect cleanup clears a held floor.
+- Held floors time out after the maximum duration.
+- `/v1/realtime` requires joined active-room state before floor requests and returns busy denial for competing speakers.

--- a/docs/engineering/strict-p2p-webrtc-audio.md
+++ b/docs/engineering/strict-p2p-webrtc-audio.md
@@ -11,6 +11,7 @@ This phase establishes the enforceable strict-P2P contracts before native media 
 - Device IDs choose the initial offerer deterministically: the lexicographically smaller device ID offers.
 - Offers, answers, and ICE candidates are sent through the existing realtime signaling envelope.
 - Leaving or switching rooms closes all tracked peer connections and disables publishing.
+- PTT floor control gates microphone publishing on a valid local floor token; see [`ptt-floor-control.md`](ptt-floor-control.md).
 
 ## Not Yet Implemented
 
@@ -29,10 +30,12 @@ Automated Swift coverage:
 - API client fetches `/v1/ice-config` with bearer auth and validates the response.
 - Room snapshots decode the backend JSON keys.
 - Peer manager creates per-peer connections, selects the deterministic offerer, sends signaling envelopes, and closes connections on room leave.
+- Floor-control state keeps publishing disabled until a local grant and clears it on release, denial, timeout, reconnect, and P2P failure.
 
 Automated Go coverage:
 
 - Backend `/v1/ice-config` requires a bearer session.
 - Backend ICE config response is STUN-only and has `relayPolicy: "disabled"`.
+- Backend realtime floor control grants one speaker, denies busy requests, releases by token, clears on disconnect, and times out held floors.
 
 CI runs both Swift and Go test suites for pull requests. Local Go verification requires Go 1.22 or newer.

--- a/internal/httpapi/realtime_test.go
+++ b/internal/httpapi/realtime_test.go
@@ -157,6 +157,76 @@ func TestRealtimeSignalingIsForwardedOnlyInsideJoinedRoom(t *testing.T) {
 	}
 }
 
+func TestRealtimeFloorControlRequiresJoinedRoomAndAllowsOneSpeaker(t *testing.T) {
+	srv := httptest.NewServer(newTestServer(t, "alice@example.com", "bob@example.com"))
+	defer srv.Close()
+
+	alice := signIn(t, srv.Config.Handler, "alice@example.com")
+	bob := signIn(t, srv.Config.Handler, "bob@example.com")
+	conversation := decodeResponse[createConversationResponse](t, postJSON(t, srv.Config.Handler, "/v1/conversations", map[string]any{
+		"type":      "direct",
+		"memberIds": []string{bob.UserID},
+	}, alice.Token)).Conversation
+
+	aliceWS := dialWebSocket(t, srv.URL, "/v1/realtime", alice.Token)
+	defer aliceWS.Close()
+	bobWS := dialWebSocket(t, srv.URL, "/v1/realtime", bob.Token)
+	defer bobWS.Close()
+
+	writeFloorRequest(t, aliceWS, conversation.ID, alice.DeviceID, "alice-floor-before-join")
+	errorEvent := aliceWS.ReadJSON(t)
+	if errorEvent["type"] != "error" || errorEvent["conversationId"] != conversation.ID {
+		t.Fatalf("floor before join event = %+v, want conversation error", errorEvent)
+	}
+	if payload := errorEvent["payload"].(map[string]any); payload["code"] != "not_joined" {
+		t.Fatalf("floor before join error payload = %+v, want not_joined", payload)
+	}
+
+	joinRoom(t, aliceWS, conversation.ID, "alice-join")
+	joinRoom(t, bobWS, conversation.ID, "bob-join")
+	if presence := aliceWS.ReadJSON(t); presence["type"] != "presence.updated" {
+		t.Fatalf("alice event after bob join = %+v, want presence.updated", presence)
+	}
+
+	writeFloorRequest(t, aliceWS, conversation.ID, alice.DeviceID, "alice-floor")
+	granted := aliceWS.ReadJSON(t)
+	if granted["type"] != "floor.granted" {
+		t.Fatalf("alice floor event = %+v, want floor.granted", granted)
+	}
+	grantPayload := granted["payload"].(map[string]any)
+	tokenID, _ := grantPayload["tokenId"].(string)
+	if tokenID == "" || grantPayload["speakerUserId"] != alice.UserID || grantPayload["speakerDeviceId"] != alice.DeviceID {
+		t.Fatalf("grant payload = %+v, want alice token", grantPayload)
+	}
+	if changed := bobWS.ReadJSON(t); changed["type"] != "floor.changed" {
+		t.Fatalf("bob event after alice grant = %+v, want floor.changed", changed)
+	}
+
+	writeFloorRequest(t, bobWS, conversation.ID, bob.DeviceID, "bob-floor")
+	denied := bobWS.ReadJSON(t)
+	if denied["type"] != "floor.denied" {
+		t.Fatalf("bob floor event = %+v, want floor.denied", denied)
+	}
+	if payload := denied["payload"].(map[string]any); payload["reason"] != "busy" || payload["speakerUserId"] != alice.UserID {
+		t.Fatalf("denied payload = %+v, want busy with alice speaker", payload)
+	}
+
+	bobWS.Close()
+	released := aliceWS.ReadJSON(t)
+	if released["type"] != "presence.updated" {
+		t.Fatalf("alice event after bob close = %+v, want presence.updated", released)
+	}
+
+	writeFloorRelease(t, aliceWS, conversation.ID, tokenID, "alice-release")
+	released = aliceWS.ReadJSON(t)
+	if released["type"] != "floor.released" {
+		t.Fatalf("alice release event = %+v, want floor.released", released)
+	}
+	if payload := released["payload"].(map[string]any); payload["tokenId"] != tokenID || payload["reason"] != "released" {
+		t.Fatalf("released payload = %+v, want token released", payload)
+	}
+}
+
 func joinRoom(t *testing.T, ws *testWebSocket, conversationID string, eventID string) {
 	t.Helper()
 
@@ -170,6 +240,36 @@ func joinRoom(t *testing.T, ws *testWebSocket, conversationID string, eventID st
 	if event := ws.ReadJSON(t); event["type"] != "room.snapshot" {
 		t.Fatalf("join event type = %v, want room.snapshot", event["type"])
 	}
+}
+
+func writeFloorRequest(t *testing.T, ws *testWebSocket, conversationID string, deviceID string, eventID string) {
+	t.Helper()
+
+	ws.WriteJSON(t, map[string]any{
+		"type":           "floor.request",
+		"id":             eventID,
+		"conversationId": conversationID,
+		"sentAt":         time.Now().UTC().Format(time.RFC3339Nano),
+		"payload": map[string]any{
+			"conversationId": conversationID,
+			"deviceId":       deviceID,
+		},
+	})
+}
+
+func writeFloorRelease(t *testing.T, ws *testWebSocket, conversationID string, tokenID string, eventID string) {
+	t.Helper()
+
+	ws.WriteJSON(t, map[string]any{
+		"type":           "floor.release",
+		"id":             eventID,
+		"conversationId": conversationID,
+		"sentAt":         time.Now().UTC().Format(time.RFC3339Nano),
+		"payload": map[string]any{
+			"conversationId": conversationID,
+			"tokenId":        tokenID,
+		},
+	})
 }
 
 type testWebSocket struct {

--- a/internal/realtime/floor.go
+++ b/internal/realtime/floor.go
@@ -1,0 +1,160 @@
+package realtime
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"toki/internal/auth"
+)
+
+const (
+	floorDeniedBusy        = "busy"
+	floorReleasedReleased  = "released"
+	floorReleasedDisconnect = "disconnect"
+	floorReleasedTimeout   = "timeout"
+	floorReleasedServerReset = "server_reset"
+)
+
+type floorRequester struct {
+	connectionID string
+	userID       string
+	deviceID     string
+}
+
+type floorLease struct {
+	conversationID string
+	tokenID        string
+	connectionID   string
+	speakerUserID  string
+	speakerDeviceID string
+	grantedAt      time.Time
+	expiresAt      time.Time
+}
+
+type floorRegistry struct {
+	mu  sync.Mutex
+	ttl time.Duration
+	byConversation map[string]floorLease
+}
+
+func newFloorRegistry(ttl time.Duration) *floorRegistry {
+	return &floorRegistry{
+		ttl:            ttl,
+		byConversation: make(map[string]floorLease),
+	}
+}
+
+func (r *floorRegistry) request(conversationID string, requester floorRequester, now time.Time) (floorGrantPayload, *floorDeniedPayload) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.expireLocked(now)
+	if current, ok := r.byConversation[conversationID]; ok {
+		return floorGrantPayload{}, &floorDeniedPayload{
+			ConversationID:  conversationID,
+			Reason:          floorDeniedBusy,
+			SpeakerUserID:   stringPtr(current.speakerUserID),
+			SpeakerDeviceID: stringPtr(current.speakerDeviceID),
+		}
+	}
+
+	tokenID, err := auth.NewToken()
+	if err != nil {
+		tokenID = fmt.Sprintf("floor-%d", now.UnixNano())
+	}
+	lease := floorLease{
+		conversationID:  conversationID,
+		tokenID:         tokenID,
+		connectionID:    requester.connectionID,
+		speakerUserID:   requester.userID,
+		speakerDeviceID: requester.deviceID,
+		grantedAt:       now.UTC(),
+		expiresAt:       now.UTC().Add(r.ttl),
+	}
+	r.byConversation[conversationID] = lease
+	return floorGrantPayload{
+		ConversationID:  conversationID,
+		TokenID:         tokenID,
+		SpeakerUserID:   requester.userID,
+		SpeakerDeviceID: requester.deviceID,
+		GrantedAt:       lease.grantedAt,
+	}, nil
+}
+
+func (r *floorRegistry) release(conversationID string, tokenID string, connectionID string, reason string) *floorReleasedPayload {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	current, ok := r.byConversation[conversationID]
+	if !ok || current.tokenID != tokenID || current.connectionID != connectionID {
+		return nil
+	}
+	delete(r.byConversation, conversationID)
+	return &floorReleasedPayload{
+		ConversationID: conversationID,
+		TokenID:        tokenID,
+		Reason:         reason,
+	}
+}
+
+func (r *floorRegistry) releaseForConnection(connectionID string, reason string) *floorReleasedPayload {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for conversationID, current := range r.byConversation {
+		if current.connectionID != connectionID {
+			continue
+		}
+		delete(r.byConversation, conversationID)
+		return &floorReleasedPayload{
+			ConversationID: conversationID,
+			TokenID:        current.tokenID,
+			Reason:         reason,
+		}
+	}
+	return nil
+}
+
+func (r *floorRegistry) expire(now time.Time) []floorReleasedPayload {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.expireLocked(now)
+}
+
+func (r *floorRegistry) snapshot(conversationID string, now time.Time) floorPayload {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.expireLocked(now)
+	current, ok := r.byConversation[conversationID]
+	if !ok {
+		return floorPayload{State: "idle"}
+	}
+	return floorPayload{
+		State:                 "held",
+		ActiveSpeakerID:       stringPtr(current.speakerUserID),
+		ActiveSpeakerDeviceID: stringPtr(current.speakerDeviceID),
+	}
+}
+
+func (r *floorRegistry) expireLocked(now time.Time) []floorReleasedPayload {
+	var released []floorReleasedPayload
+	for conversationID, current := range r.byConversation {
+		if now.Before(current.expiresAt) {
+			continue
+		}
+		delete(r.byConversation, conversationID)
+		released = append(released, floorReleasedPayload{
+			ConversationID: conversationID,
+			TokenID:        current.tokenID,
+			Reason:         floorReleasedTimeout,
+		})
+	}
+	return released
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/internal/realtime/floor_test.go
+++ b/internal/realtime/floor_test.go
@@ -1,0 +1,76 @@
+package realtime
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFloorRegistryGrantsDeniesReleasesAndCleansUp(t *testing.T) {
+	registry := newFloorRegistry(5 * time.Minute)
+	now := time.Date(2026, 7, 6, 10, 0, 0, 0, time.UTC)
+	alice := floorRequester{connectionID: "connection-a", userID: "user-a", deviceID: "device-a"}
+	bob := floorRequester{connectionID: "connection-b", userID: "user-b", deviceID: "device-b"}
+
+	grant, denied := registry.request("conversation-1", alice, now)
+	if denied != nil {
+		t.Fatalf("first request denial = %+v, want grant", denied)
+	}
+	if grant.ConversationID != "conversation-1" || grant.SpeakerUserID != alice.userID || grant.SpeakerDeviceID != alice.deviceID || grant.TokenID == "" {
+		t.Fatalf("grant = %+v, want alice floor token", grant)
+	}
+
+	_, denied = registry.request("conversation-1", bob, now.Add(time.Second))
+	if denied == nil || denied.Reason != floorDeniedBusy || denied.SpeakerUserID == nil || *denied.SpeakerUserID != alice.userID {
+		t.Fatalf("busy denial = %+v, want alice as active speaker", denied)
+	}
+
+	if released := registry.release("conversation-1", "wrong-token", alice.connectionID, floorReleasedReleased); released != nil {
+		t.Fatalf("wrong token release = %+v, want nil", released)
+	}
+
+	if released := registry.release("conversation-1", grant.TokenID, bob.connectionID, floorReleasedReleased); released != nil {
+		t.Fatalf("non-holder release = %+v, want nil", released)
+	}
+
+	released := registry.release("conversation-1", grant.TokenID, alice.connectionID, floorReleasedReleased)
+	if released == nil || released.TokenID != grant.TokenID || released.Reason != floorReleasedReleased {
+		t.Fatalf("release = %+v, want released token", released)
+	}
+
+	bobGrant, denied := registry.request("conversation-1", bob, now.Add(2*time.Second))
+	if denied != nil {
+		t.Fatalf("bob request denial = %+v, want grant after release", denied)
+	}
+
+	released = registry.releaseForConnection("connection-b", floorReleasedDisconnect)
+	if released == nil || released.TokenID != bobGrant.TokenID || released.Reason != floorReleasedDisconnect {
+		t.Fatalf("disconnect cleanup = %+v, want bob token released", released)
+	}
+}
+
+func TestFloorRegistryExpiresHeldFloors(t *testing.T) {
+	registry := newFloorRegistry(5 * time.Minute)
+	now := time.Date(2026, 7, 6, 10, 0, 0, 0, time.UTC)
+	grant, denied := registry.request("conversation-1", floorRequester{
+		connectionID: "connection-a",
+		userID:       "user-a",
+		deviceID:     "device-a",
+	}, now)
+	if denied != nil {
+		t.Fatalf("request denial = %+v, want grant", denied)
+	}
+
+	expired := registry.expire(now.Add(5*time.Minute + time.Nanosecond))
+	if len(expired) != 1 || expired[0].TokenID != grant.TokenID || expired[0].Reason != floorReleasedTimeout {
+		t.Fatalf("expired floors = %+v, want one timeout release", expired)
+	}
+
+	nextGrant, denied := registry.request("conversation-1", floorRequester{
+		connectionID: "connection-b",
+		userID:       "user-b",
+		deviceID:     "device-b",
+	}, now.Add(6*time.Minute))
+	if denied != nil || nextGrant.TokenID == "" {
+		t.Fatalf("request after timeout grant = %+v denial=%+v, want grant", nextGrant, denied)
+	}
+}

--- a/internal/realtime/hub.go
+++ b/internal/realtime/hub.go
@@ -23,6 +23,7 @@ type Logger interface {
 type Hub struct {
 	store  store.Store
 	logger Logger
+	floors *floorRegistry
 
 	mu    sync.Mutex
 	rooms map[string]*room
@@ -48,6 +49,7 @@ func NewHub(st store.Store, logger Logger) *Hub {
 	return &Hub{
 		store:  st,
 		logger: logger,
+		floors: newFloorRegistry(5 * time.Minute),
 		rooms:  make(map[string]*room),
 	}
 }
@@ -108,6 +110,10 @@ func (h *Hub) handleEvent(ctx context.Context, c *client, event EventEnvelope) {
 		h.handlePresenceSet(c, event)
 	case EventSignalOffer, EventSignalAnswer, EventSignalICECandidate:
 		h.handleSignal(c, event)
+	case EventFloorRequest:
+		h.handleFloorRequest(ctx, c, event)
+	case EventFloorRelease:
+		h.handleFloorRelease(c, event)
 	default:
 		h.sendError(c, event.ID, event.ConversationID, "unknown_event", "unsupported realtime event")
 	}
@@ -152,6 +158,9 @@ func (h *Hub) handleJoin(ctx context.Context, c *client, event EventEnvelope) {
 
 	if oldUpdate != nil {
 		h.broadcast(oldRecipients, EventPresenceUpdated, "", oldUpdate.ConversationID, *oldUpdate)
+		if released := h.floors.releaseForConnection(c.connectionID, floorReleasedDisconnect); released != nil {
+			h.broadcast(oldRecipients, EventFloorReleased, "", released.ConversationID, *released)
+		}
 	}
 	h.send(c, EventRoomSnapshot, event.ID, conversation.ID, snapshot)
 	h.broadcast(recipients, EventPresenceUpdated, "", conversation.ID, update)
@@ -161,6 +170,9 @@ func (h *Hub) handleLeave(c *client, event EventEnvelope) {
 	recipients, update := h.leave(c, "left")
 	if update != nil {
 		h.broadcast(recipients, EventPresenceUpdated, event.ID, update.ConversationID, *update)
+	}
+	if released := h.floors.releaseForConnection(c.connectionID, floorReleasedReleased); released != nil {
+		h.broadcast(recipients, EventFloorReleased, event.ID, released.ConversationID, *released)
 	}
 }
 
@@ -225,10 +237,102 @@ func (h *Hub) handleSignal(c *client, event EventEnvelope) {
 	h.send(target, EventSignalForwarded, event.ID, event.ConversationID, payload)
 }
 
+func (h *Hub) handleFloorRequest(ctx context.Context, c *client, event EventEnvelope) {
+	if strings.TrimSpace(event.ConversationID) == "" {
+		h.sendError(c, event.ID, "", "missing_conversation", "conversationId is required")
+		return
+	}
+	if _, err := h.authorizedConversation(ctx, c.userID, event.ConversationID); err != nil {
+		h.sendError(c, event.ID, event.ConversationID, "forbidden", "conversation is unavailable")
+		return
+	}
+	var payload floorRequestPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		h.sendError(c, event.ID, event.ConversationID, "invalid_payload", "floor request payload is invalid")
+		return
+	}
+	if strings.TrimSpace(payload.ConversationID) == "" || payload.ConversationID != event.ConversationID {
+		h.sendError(c, event.ID, event.ConversationID, "missing_conversation", "conversationId is required")
+		return
+	}
+	if strings.TrimSpace(payload.DeviceID) == "" || payload.DeviceID != c.deviceID {
+		h.sendError(c, event.ID, event.ConversationID, "invalid_device", "floor request deviceId must match the session device")
+		return
+	}
+
+	h.mu.Lock()
+	joined := c.conversationID == event.ConversationID && c.active
+	targetRoom := h.rooms[event.ConversationID]
+	h.mu.Unlock()
+	if !joined {
+		h.sendError(c, event.ID, event.ConversationID, "not_joined", "join the active room before requesting the floor")
+		return
+	}
+
+	grant, denied := h.floors.request(event.ConversationID, floorRequester{
+		connectionID: c.connectionID,
+		userID:       c.userID,
+		deviceID:     c.deviceID,
+	}, time.Now().UTC())
+	if denied != nil {
+		h.send(c, EventFloorDenied, event.ID, event.ConversationID, *denied)
+		return
+	}
+
+	h.mu.Lock()
+	recipients := h.roomClientsLocked(targetRoom, c.connectionID)
+	h.mu.Unlock()
+
+	h.send(c, EventFloorGranted, event.ID, event.ConversationID, grant)
+	h.broadcast(recipients, EventFloorChanged, "", event.ConversationID, floorChangedPayload{
+		ConversationID:  event.ConversationID,
+		State:           "held",
+		SpeakerUserID:   grant.SpeakerUserID,
+		SpeakerDeviceID: grant.SpeakerDeviceID,
+	})
+	h.scheduleFloorTimeout()
+}
+
+func (h *Hub) handleFloorRelease(c *client, event EventEnvelope) {
+	var payload floorReleasePayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		h.sendError(c, event.ID, event.ConversationID, "invalid_payload", "floor release payload is invalid")
+		return
+	}
+	if strings.TrimSpace(event.ConversationID) == "" || payload.ConversationID != event.ConversationID {
+		h.sendError(c, event.ID, event.ConversationID, "missing_conversation", "conversationId is required")
+		return
+	}
+	if strings.TrimSpace(payload.TokenID) == "" {
+		h.sendError(c, event.ID, event.ConversationID, "missing_floor_token", "tokenId is required")
+		return
+	}
+
+	h.mu.Lock()
+	joined := c.conversationID == event.ConversationID
+	targetRoom := h.rooms[event.ConversationID]
+	recipients := h.roomClientsLocked(targetRoom, "")
+	h.mu.Unlock()
+	if !joined {
+		h.sendError(c, event.ID, event.ConversationID, "not_joined", "join the conversation before releasing the floor")
+		return
+	}
+
+	released := h.floors.release(event.ConversationID, payload.TokenID, c.connectionID, floorReleasedReleased)
+	if released == nil {
+		h.sendError(c, event.ID, event.ConversationID, "invalid_floor_token", "floor token is not active")
+		return
+	}
+	h.broadcast(recipients, EventFloorReleased, event.ID, event.ConversationID, *released)
+}
+
 func (h *Hub) disconnect(c *client) {
 	recipients, update := h.leave(c, "left")
 	if update != nil {
 		h.broadcast(recipients, EventPresenceUpdated, "", update.ConversationID, *update)
+	}
+	if released := h.floors.releaseForConnection(c.connectionID, floorReleasedDisconnect); released != nil {
+		h.broadcast(recipients, EventFloorReleased, "", released.ConversationID, *released)
 	}
 	_ = c.ws.close()
 }
@@ -295,10 +399,7 @@ func (h *Hub) snapshotLocked(conversationID string, targetRoom *room) roomSnapsh
 		ConversationID: conversationID,
 		Peers:          h.peersLocked(targetRoom),
 		Presence:       h.presenceLocked(targetRoom),
-		Floor: floorPayload{
-			State:           "idle",
-			ActiveSpeakerID: nil,
-		},
+		Floor:          h.floors.snapshot(conversationID, time.Now().UTC()),
 	}
 }
 
@@ -386,6 +487,17 @@ func (h *Hub) send(c *client, eventType string, eventID string, conversationID s
 
 func (h *Hub) sendError(c *client, eventID string, conversationID string, code string, message string) {
 	h.send(c, EventError, eventID, conversationID, errorPayload{Code: code, Message: message})
+}
+
+func (h *Hub) scheduleFloorTimeout() {
+	time.AfterFunc(h.floors.ttl, func() {
+		for _, released := range h.floors.expire(time.Now().UTC()) {
+			h.mu.Lock()
+			recipients := h.roomClientsLocked(h.rooms[released.ConversationID], "")
+			h.mu.Unlock()
+			h.broadcast(recipients, EventFloorReleased, "", released.ConversationID, released)
+		}
+	})
 }
 
 func (h *Hub) requireSession(w http.ResponseWriter, r *http.Request) (store.SessionBundle, bool) {

--- a/internal/realtime/protocol.go
+++ b/internal/realtime/protocol.go
@@ -15,6 +15,12 @@ const (
 	EventSignalAnswer       = "signal.answer"
 	EventSignalICECandidate = "signal.iceCandidate"
 	EventSignalForwarded    = "signal.forwarded"
+	EventFloorRequest       = "floor.request"
+	EventFloorGranted       = "floor.granted"
+	EventFloorDenied        = "floor.denied"
+	EventFloorRelease       = "floor.release"
+	EventFloorReleased      = "floor.released"
+	EventFloorChanged       = "floor.changed"
 	EventError              = "error"
 	EventReconnectRequired  = "reconnect.required"
 )
@@ -52,8 +58,9 @@ type presencePayload struct {
 }
 
 type floorPayload struct {
-	State           string  `json:"state"`
-	ActiveSpeakerID *string `json:"activeSpeakerId"`
+	State                 string  `json:"state"`
+	ActiveSpeakerID       *string `json:"activeSpeakerId,omitempty"`
+	ActiveSpeakerDeviceID *string `json:"activeSpeakerDeviceId,omitempty"`
 }
 
 type roomSnapshotPayload struct {
@@ -75,4 +82,43 @@ type presenceUpdatedPayload struct {
 type errorPayload struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+}
+
+type floorRequestPayload struct {
+	ConversationID string `json:"conversationId"`
+	DeviceID       string `json:"deviceId"`
+}
+
+type floorGrantPayload struct {
+	ConversationID  string    `json:"conversationId"`
+	TokenID         string    `json:"tokenId"`
+	SpeakerUserID   string    `json:"speakerUserId"`
+	SpeakerDeviceID string    `json:"speakerDeviceId"`
+	GrantedAt       time.Time `json:"grantedAt"`
+}
+
+type floorDeniedPayload struct {
+	ConversationID  string  `json:"conversationId"`
+	Reason          string  `json:"reason"`
+	SpeakerUserID   *string `json:"speakerUserId,omitempty"`
+	SpeakerDeviceID *string `json:"speakerDeviceId,omitempty"`
+}
+
+type floorReleasePayload struct {
+	ConversationID string `json:"conversationId"`
+	TokenID        string `json:"tokenId"`
+}
+
+type floorReleasedPayload struct {
+	ConversationID string `json:"conversationId"`
+	TokenID        string `json:"tokenId"`
+	Reason         string `json:"reason"`
+}
+
+type floorChangedPayload struct {
+	ConversationID  string `json:"conversationId"`
+	State           string `json:"state"`
+	SpeakerUserID   string `json:"speakerUserId,omitempty"`
+	SpeakerDeviceID string `json:"speakerDeviceId,omitempty"`
+	Reason          string `json:"reason,omitempty"`
 }

--- a/plans/05-ptt-floor-control.md
+++ b/plans/05-ptt-floor-control.md
@@ -27,19 +27,19 @@
 
 ## Implementation Steps
 
-- [ ] Define floor event payloads with conversation ID, user ID, device ID, token ID, and server timestamp.
-- [ ] Implement `floor.request` handling with membership and active-room validation.
-- [ ] Grant the floor only if the conversation has no current speaker.
-- [ ] Deny the floor with reason `busy` when another device holds it.
-- [ ] Broadcast `floor.granted` to requester and `presence.updated` or `floor.changed` to listeners.
-- [ ] Implement `floor.release` requiring the current token ID.
-- [ ] Release the floor automatically when the speaking socket disconnects.
-- [ ] Add a maximum continuous hold duration for safety, such as 5 minutes, then release with reason `timeout`.
-- [ ] On client PTT press, enter requesting state and send `floor.request`.
-- [ ] Only after `floor.granted`, call `PeerConnectionManager.setPublishingEnabled(true)`.
-- [ ] On PTT release, immediately stop publishing locally and send `floor.release`.
-- [ ] If release cannot reach the backend, keep local publishing stopped and let server timeout or disconnect cleanup clear remote state.
-- [ ] Show the active speaker in the active room and menu bar while floor is held.
+- [x] Define floor event payloads with conversation ID, user ID, device ID, token ID, and server timestamp.
+- [x] Implement `floor.request` handling with membership and active-room validation.
+- [x] Grant the floor only if the conversation has no current speaker.
+- [x] Deny the floor with reason `busy` when another device holds it.
+- [x] Broadcast `floor.granted` to requester and `presence.updated` or `floor.changed` to listeners.
+- [x] Implement `floor.release` requiring the current token ID.
+- [x] Release the floor automatically when the speaking socket disconnects.
+- [x] Add a maximum continuous hold duration for safety, such as 5 minutes, then release with reason `timeout`.
+- [x] On client PTT press, enter requesting state and send `floor.request`.
+- [x] Only after `floor.granted`, call `PeerConnectionManager.setPublishingEnabled(true)`.
+- [x] On PTT release, immediately stop publishing locally and send `floor.release`.
+- [x] If release cannot reach the backend, keep local publishing stopped and let server timeout or disconnect cleanup clear remote state.
+- [x] Show the active speaker in the active room and menu bar while floor is held.
 
 ## Interfaces
 


### PR DESCRIPTION
## Summary

- Add backend realtime floor control with one active floor token per conversation, busy denial, token-owned release, disconnect cleanup, and timeout cleanup.
- Add Swift floor event payloads plus token-aware client state so microphone and peer publishing fail closed unless the local user holds a granted floor.
- Surface active speaker state in the main room UI and menu bar, and update README/engineering docs plus the phase checklist.

## Testing

- `rtk swift test` (39 tests passing)
- `rtk swift build`
- `rtk git diff --check`
- `rtk git diff --cached --check`

Local Go verification could not run in this environment because `rtk go test ./...` fails with `Failed to spawn process: No such file or directory (os error 2)`. CI includes the existing Go Backend job running `go test ./...`, and this PR adds Go floor-control tests for that job.