### PR TITLE
[codex] Add beta release observability and QA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,15 @@ jobs:
 
       - name: Test
         run: go test ./...
+
+  pre-beta-policy:
+    name: Pre-Beta Policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Check strict P2P and privacy policy
+        run: scripts/check-prebeta-policy.sh

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The media policy is strict peer-to-peer for the MVP. The backend may coordinate 
 - PTT floor control: backend grants one ephemeral floor token per conversation, denies concurrent speakers, and clears held floors on release, disconnect, timeout, or backend restart.
 - Strict P2P media foundation: authenticated STUN-only ICE config, client-side TURN/relay rejection, and a protocol-backed peer connection manager for active-room mesh setup.
 - Local audio controls: dynamic microphone/output device selection, mic test/input level state, active-speaker output level state, and local-only replay state capped at 2 minutes.
+- Beta release readiness: Developer ID/notarization runbook, beta appcast template, metadata-only diagnostics models, structured privacy-safe backend request logging, QA matrix, and a CI pre-beta policy check.
 
 ## Product Constraints
 
@@ -48,6 +49,12 @@ Run the backend test suite when Go is installed:
 
 ```bash
 rtk go test ./...
+```
+
+Run the pre-beta strict P2P/privacy policy check:
+
+```bash
+rtk scripts/check-prebeta-policy.sh
 ```
 
 Run the realtime-focused Swift tests:
@@ -128,6 +135,7 @@ Implemented in the current foundation:
 - `StrictP2PICEPolicy` rejects TURN URLs, relay policy changes, and relay ICE candidates.
 - `PeerConnectionManager` creates peer connections from `room.snapshot`, uses lexicographic device IDs for deterministic offerer selection, forwards offer/answer/candidate signaling over the realtime transport, and closes all peer connections when leaving or switching rooms.
 - `AppSessionState` gates local microphone publishing on a valid local floor token, and `PeerConnectionManager.applyFloor` enables peer publishing only for a local grant.
+- `scripts/check-prebeta-policy.sh` runs in CI and verifies the release config keeps TURN and server media disabled while checking runtime paths for forbidden relay or server-media terms.
 
 Still intentionally pending until the native WebRTC dependency is selected and wired:
 
@@ -150,8 +158,19 @@ Implemented in the current client foundation:
 
 The replay buffer is not persisted to disk, `UserDefaults`, backend APIs, logs, crash reports, analytics, or diagnostics. See [`docs/engineering/local-replay-and-audio-devices.md`](docs/engineering/local-replay-and-audio-devices.md) for the implementation contract.
 
+## Beta Release And Diagnostics
+
+Release readiness artifacts live under [`docs/release`](docs/release) and [`release`](release):
+
+- [`docs/release/beta-release.md`](docs/release/beta-release.md) covers Developer ID signing, notarization, beta appcast publication, backend deployment, diagnostics limits, and the pre-beta gate.
+- [`docs/release/qa-matrix.md`](docs/release/qa-matrix.md) is the manual QA matrix for install, permissions, LAN calls, 10-person rooms, simultaneous PTT, reconnect, backend restart, device unplug, restrictive-network failure, replay, diagnostics, and updates.
+- [`release/beta-release.json`](release/beta-release.json) records the beta channel defaults and strict P2P media policy.
+- [`release/beta-appcast.template.xml`](release/beta-appcast.template.xml) is the Sparkle-compatible beta feed template.
+
+The app exposes version, build, and update channel in Settings. Diagnostics exports are metadata-only and must be initiated by the user. Backend request logs are structured and redact tokens, emails, SDP, ICE candidate bodies, audio, and replay terms.
+
 ## Verification Notes
 
 The backend realtime channel intentionally avoids audio paths. Re-check this before merging any future WebRTC, replay, diagnostics, or observability changes.
 
-CI runs the full Swift package tests and Go backend tests on pull requests. The current automated coverage includes strict ICE validation, authenticated ICE config fetching, peer mesh lifecycle/signaling behavior, token-aware PTT floor state, realtime floor request/release encoding, local replay capacity/clearing/privacy behavior, audio device selection/fallback behavior, mic-test level behavior, app-shell replay controls, backend floor grant/deny/release/disconnect/timeout behavior, and the backend ICE config endpoint. Local Go verification requires Go 1.22 or newer to be installed.
+CI runs the full Swift package tests, Go backend tests, and the pre-beta policy check on pull requests. The current automated coverage includes strict ICE validation, authenticated ICE config fetching, peer mesh lifecycle/signaling behavior, token-aware PTT floor state, realtime floor request/release encoding, local replay capacity/clearing/privacy behavior, audio device selection/fallback behavior, mic-test level behavior, app-shell replay controls, diagnostics redaction, release readiness gates, backend floor grant/deny/release/disconnect/timeout behavior, backend privacy-safe log redaction, and the backend ICE config endpoint. Local Go verification requires Go 1.22 or newer to be installed.

--- a/Sources/TokiApp/AppShellModel.swift
+++ b/Sources/TokiApp/AppShellModel.swift
@@ -157,6 +157,9 @@ final class AppShellModel: ObservableObject {
     @Published private(set) var isReplayPublishingMicrophone = false
     @Published private(set) var isReplayRequestingFloor = false
     @Published private(set) var lastReplaySegments: [LocalAudioSegment] = []
+    @Published private(set) var versionLabel: String
+    @Published private(set) var buildLabel: String
+    @Published private(set) var updateChannelLabel: String
 
     private let apiService: AppShellAPIService
     private let sessionTokenStore: SessionTokenStoring
@@ -175,7 +178,8 @@ final class AppShellModel: ObservableObject {
         permissionCoordinator: PermissionCoordinating = PermissionCoordinator.live(),
         settingsStore: SettingsStoring = LocalSettingsStore(defaults: .standard),
         audioDeviceProvider: AudioDeviceProviding = SystemAudioDeviceProvider(),
-        microphoneTestController: MicrophoneTestController = MicrophoneTestController()
+        microphoneTestController: MicrophoneTestController = MicrophoneTestController(),
+        releaseMetadata: AppReleaseMetadata = .current()
     ) {
         self.apiService = apiService
         self.sessionTokenStore = sessionTokenStore
@@ -183,6 +187,9 @@ final class AppShellModel: ObservableObject {
         self.settingsStore = settingsStore
         self.audioDeviceManager = AudioDeviceManager(provider: audioDeviceProvider, settingsStore: settingsStore)
         self.microphoneTestController = microphoneTestController
+        self.versionLabel = "Version \(releaseMetadata.version)"
+        self.buildLabel = "Build \(releaseMetadata.buildNumber)"
+        self.updateChannelLabel = releaseMetadata.updateChannel.label
         loadSettings()
     }
 

--- a/Sources/TokiApp/SettingsView.swift
+++ b/Sources/TokiApp/SettingsView.swift
@@ -41,6 +41,21 @@ struct SettingsView: View {
             Toggle("Launch At Login", isOn: $model.launchAtLogin)
             Toggle("Diagnostics Opt-In", isOn: $model.diagnosticsOptIn)
 
+            Section("Release") {
+                HStack {
+                    Text(model.versionLabel)
+                    Spacer()
+                    Text(model.buildLabel)
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Text("Update Channel")
+                    Spacer()
+                    Text(model.updateChannelLabel)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             Text("Global shortcut capture stays local in this slice. Audio transport and device activation are intentionally not implemented here.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)

--- a/Sources/TokiCore/AppSessionState.swift
+++ b/Sources/TokiCore/AppSessionState.swift
@@ -39,7 +39,7 @@ public enum SessionActivity: Equatable, Sendable {
     case permissionDenied(PermissionKind)
 }
 
-public struct PermissionState: Equatable, Sendable {
+public struct PermissionState: Codable, Equatable, Sendable {
     public let microphone: PermissionStatus
     public let inputMonitoring: PermissionStatus
 
@@ -61,6 +61,7 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
     @Published public private(set) var lastReleasedFloorTokenID: FloorTokenID?
     @Published public private(set) var replayAvailableDuration: TimeInterval = 0
     @Published public private(set) var lastReplayClearReason: ReplayClearReason?
+    @Published public private(set) var diagnosticsEvents: [DiagnosticsEventSummary] = []
 
     private let permissions: PermissionCoordinating
     private let replayBuffer: LocalReplayBuffer
@@ -108,6 +109,7 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
 
     public func updateDevicePreferences(_ preferences: DevicePreferences) {
         devicePreferences = preferences
+        recordDiagnosticsEvent(category: .deviceFallback, state: "device.preferences.updated")
     }
 
     public func selectConversation(id: ConversationID) {
@@ -118,6 +120,7 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
         realtimeConnection = .listening
         floor = .idle
         activity = .listening
+        recordDiagnosticsEvent(category: .room, state: "room.join")
     }
 
     public func appendReceivedAudio(_ segment: LocalAudioSegment, conversationID: ConversationID) {
@@ -146,6 +149,7 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
         shouldPublishMicrophone = false
         isPushToTalkActive = false
         clearReplay(reason: .signOut)
+        recordDiagnosticsEvent(category: .auth, state: "signed.out")
     }
 
     public func clearReplayForAppTermination() {
@@ -185,6 +189,7 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
             isPushToTalkActive = false
             floor = .blocked(reason: .microphoneDenied)
             activity = .permissionDenied(.microphone)
+            recordDiagnosticsEvent(category: .permission, state: "microphone.denied")
             return
         }
 
@@ -192,6 +197,7 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
             isPushToTalkActive = false
             floor = .blocked(reason: .inputMonitoringDenied)
             activity = .permissionDenied(.inputMonitoring)
+            recordDiagnosticsEvent(category: .permission, state: "input_monitoring.denied")
             return
         }
 
@@ -205,6 +211,7 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
         lastReleasedFloorTokenID = nil
         floor = .requesting(localUserID: localUserID)
         activity = .requestingFloor
+        recordDiagnosticsEvent(category: .floor, state: "floor.requesting")
     }
 
     public func floorGrantReceived(tokenID: FloorTokenID, speakerID: UserID) {
@@ -212,12 +219,14 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
             floor = .granted(speakerID: speakerID, tokenID: tokenID)
             activity = .speaking
             shouldPublishMicrophone = true
+            recordDiagnosticsEvent(category: .floor, state: "floor.granted")
             return
         }
 
         shouldPublishMicrophone = false
         floor = .busy(speakerID: speakerID)
         activity = .floorBusy
+        recordDiagnosticsEvent(category: .floor, state: "floor.busy")
     }
 
     public func floorDeniedReceived(reason: FloorDeniedReason, speakerID: UserID? = nil) {
@@ -231,6 +240,7 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
             floor = .idle
             activity = activeConversationID == nil ? .idle : .listening
         }
+        recordDiagnosticsEvent(category: .floor, state: "floor.denied.\(reason.rawValue)")
     }
 
     public func floorReleasedReceived(tokenID: FloorTokenID, reason: FloorReleasedReason) {
@@ -239,6 +249,7 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
         shouldPublishMicrophone = false
         floor = .idle
         activity = activeConversationID == nil ? .idle : .listening
+        recordDiagnosticsEvent(category: .floor, state: "floor.released.\(reason.rawValue)")
     }
 
     public func pushToTalkReleased() {
@@ -256,6 +267,7 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
 
         floor = .idle
         activity = .listening
+        recordDiagnosticsEvent(category: .floor, state: "floor.released.local")
     }
 
     public func connectionChanged(_ state: RealtimeConnectionState) {
@@ -280,11 +292,43 @@ public final class AppSessionState: ObservableObject, @unchecked Sendable {
             floor = .idle
             activity = .p2pUnavailable
         }
+        recordDiagnosticsEvent(category: .realtime, state: state.diagnosticsState)
     }
 
     private func clearReplay(reason: ReplayClearReason) {
         replayBuffer.clear(reason: reason)
         replayAvailableDuration = replayBuffer.availableDuration
         lastReplayClearReason = replayBuffer.lastClearReason
+    }
+
+    private func recordDiagnosticsEvent(category: DiagnosticsEventCategory, state: String) {
+        diagnosticsEvents.append(
+            DiagnosticsEventSummary(
+                category: category,
+                conversationID: activeConversationID,
+                peerID: nil,
+                state: state
+            )
+        )
+        if diagnosticsEvents.count > 200 {
+            diagnosticsEvents.removeFirst(diagnosticsEvents.count - 200)
+        }
+    }
+}
+
+private extension RealtimeConnectionState {
+    var diagnosticsState: String {
+        switch self {
+        case .disconnected:
+            "disconnected"
+        case .connected:
+            "connected"
+        case .listening:
+            "listening"
+        case .reconnecting:
+            "reconnecting"
+        case .p2pUnavailable:
+            "p2p.unavailable"
+        }
     }
 }

--- a/Sources/TokiCore/BetaReleaseDiagnostics.swift
+++ b/Sources/TokiCore/BetaReleaseDiagnostics.swift
@@ -1,0 +1,335 @@
+import Foundation
+
+public enum UpdateChannel: String, Codable, Equatable, Sendable {
+    case beta
+    case stable
+
+    public var label: String {
+        switch self {
+        case .beta:
+            "Beta"
+        case .stable:
+            "Stable"
+        }
+    }
+}
+
+public struct AppReleaseMetadata: Codable, Equatable, Sendable {
+    public let version: String
+    public let buildNumber: String
+    public let updateChannel: UpdateChannel
+
+    public init(version: String, buildNumber: String, updateChannel: UpdateChannel) {
+        self.version = version
+        self.buildNumber = buildNumber
+        self.updateChannel = updateChannel
+    }
+
+    public static let betaPlaceholder = AppReleaseMetadata(
+        version: "0.7.0",
+        buildNumber: "0",
+        updateChannel: .beta
+    )
+
+    public static func current(bundle: Bundle = .main, updateChannel: UpdateChannel = .beta) -> AppReleaseMetadata {
+        AppReleaseMetadata(
+            version: bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? betaPlaceholder.version,
+            buildNumber: bundle.infoDictionary?["CFBundleVersion"] as? String ?? betaPlaceholder.buildNumber,
+            updateChannel: updateChannel
+        )
+    }
+}
+
+public struct DiagnosticsDeviceSnapshot: Codable, Equatable, Sendable {
+    public let inputName: String?
+    public let outputName: String?
+
+    public init(inputName: String?, outputName: String?) {
+        self.inputName = inputName
+        self.outputName = outputName
+    }
+}
+
+public enum DiagnosticsEventCategory: String, Codable, Equatable, Sendable {
+    case auth
+    case realtime
+    case room
+    case floor
+    case peerConnection
+    case permission
+    case deviceFallback
+}
+
+public struct DiagnosticsEventSummary: Codable, Equatable, Sendable {
+    public let category: DiagnosticsEventCategory
+    public let conversationID: ConversationID?
+    public let peerID: UserID?
+    public let state: String
+    public let failureReason: String?
+
+    public init(
+        category: DiagnosticsEventCategory,
+        conversationID: ConversationID?,
+        peerID: UserID?,
+        state: String,
+        failureReason: String? = nil
+    ) {
+        self.category = category
+        self.conversationID = conversationID
+        self.peerID = peerID
+        self.state = state
+        self.failureReason = failureReason
+    }
+
+    public func redacted() -> DiagnosticsEventSummary {
+        DiagnosticsEventSummary(
+            category: category,
+            conversationID: conversationID,
+            peerID: peerID,
+            state: PrivacyRedactor.redactFreeText(state),
+            failureReason: failureReason.map(PrivacyRedactor.redactFreeText)
+        )
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case category
+        case conversationID = "conversationId"
+        case peerID = "peerId"
+        case state
+        case failureReason
+    }
+}
+
+public struct DiagnosticsExport: Codable, Equatable, Sendable {
+    public let release: AppReleaseMetadata
+    public let macOSVersion: String
+    public let deviceModel: String
+    public let permissions: PermissionState
+    public let selectedDevices: DiagnosticsDeviceSnapshot
+    public let realtimeEvents: [DiagnosticsEventSummary]
+    public let errors: [String]
+
+    public init(
+        release: AppReleaseMetadata,
+        macOSVersion: String,
+        deviceModel: String,
+        permissions: PermissionState,
+        selectedDevices: DiagnosticsDeviceSnapshot,
+        realtimeEvents: [DiagnosticsEventSummary],
+        errors: [String]
+    ) {
+        self.release = release
+        self.macOSVersion = macOSVersion
+        self.deviceModel = deviceModel
+        self.permissions = permissions
+        self.selectedDevices = selectedDevices
+        self.realtimeEvents = realtimeEvents
+        self.errors = errors
+    }
+
+    public func redacted() -> DiagnosticsExport {
+        DiagnosticsExport(
+            release: release,
+            macOSVersion: PrivacyRedactor.redactFreeText(macOSVersion),
+            deviceModel: PrivacyRedactor.redactFreeText(deviceModel),
+            permissions: permissions,
+            selectedDevices: selectedDevices,
+            realtimeEvents: realtimeEvents.map { $0.redacted() },
+            errors: errors.map(PrivacyRedactor.redactFreeText)
+        )
+    }
+}
+
+public struct PrivacySafeLogEvent: Codable, Equatable, Sendable {
+    public let category: DiagnosticsEventCategory
+    public let name: String
+    public let conversationID: ConversationID?
+    public let userID: UserID?
+    public let metadata: [String: String]
+
+    public init(
+        category: DiagnosticsEventCategory,
+        name: String,
+        conversationID: ConversationID?,
+        userID: UserID?,
+        metadata: [String: String]
+    ) {
+        self.category = category
+        self.name = name
+        self.conversationID = conversationID
+        self.userID = userID
+        self.metadata = metadata
+    }
+
+    public func redacted() -> PrivacySafeLogEvent {
+        PrivacySafeLogEvent(
+            category: category,
+            name: PrivacyRedactor.redactFreeText(name),
+            conversationID: conversationID,
+            userID: userID,
+            metadata: PrivacyRedactor.redactMetadata(metadata)
+        )
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case category
+        case name
+        case conversationID = "conversationId"
+        case userID = "userId"
+        case metadata
+    }
+}
+
+public enum NotarizationResult: String, Codable, Equatable, Sendable {
+    case notRun
+    case accepted
+    case rejected
+}
+
+public struct QAPassFailSummary: Codable, Equatable, Sendable {
+    public let passed: Int
+    public let failed: Int
+    public let blocked: Int
+
+    public init(passed: Int, failed: Int, blocked: Int) {
+        self.passed = passed
+        self.failed = failed
+        self.blocked = blocked
+    }
+
+    public var isPassing: Bool {
+        passed > 0 && failed == 0 && blocked == 0
+    }
+}
+
+public struct StrictP2PReleaseVerification: Codable, Equatable, Sendable {
+    public let turnDisabled: Bool
+    public let serverMediaDisabled: Bool
+    public let forbiddenTermsFound: [String]
+
+    public init(turnDisabled: Bool, serverMediaDisabled: Bool, forbiddenTermsFound: [String]) {
+        self.turnDisabled = turnDisabled
+        self.serverMediaDisabled = serverMediaDisabled
+        self.forbiddenTermsFound = forbiddenTermsFound
+    }
+
+    public var isVerified: Bool {
+        turnDisabled && serverMediaDisabled && forbiddenTermsFound.isEmpty
+    }
+}
+
+public enum PreBetaBlockingReason: String, Codable, Equatable, Sendable {
+    case missingSigningIdentity
+    case notarizationIncomplete
+    case missingUpdateFeedURL
+    case missingBackendVersion
+    case qaIncomplete
+    case strictP2PNotVerified
+}
+
+public struct PreBetaReleaseChecklist: Codable, Equatable, Sendable {
+    public let signingIdentity: String
+    public let notarizationResult: NotarizationResult
+    public let updateFeedURL: URL?
+    public let backendVersion: String
+    public let qaSummary: QAPassFailSummary
+    public let strictP2PVerification: StrictP2PReleaseVerification
+
+    public init(
+        signingIdentity: String,
+        notarizationResult: NotarizationResult,
+        updateFeedURL: URL?,
+        backendVersion: String,
+        qaSummary: QAPassFailSummary,
+        strictP2PVerification: StrictP2PReleaseVerification
+    ) {
+        self.signingIdentity = signingIdentity
+        self.notarizationResult = notarizationResult
+        self.updateFeedURL = updateFeedURL
+        self.backendVersion = backendVersion
+        self.qaSummary = qaSummary
+        self.strictP2PVerification = strictP2PVerification
+    }
+
+    public var isReadyForBeta: Bool {
+        blockingReasons.isEmpty
+    }
+
+    public var blockingReasons: [PreBetaBlockingReason] {
+        var reasons: [PreBetaBlockingReason] = []
+        if signingIdentity.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            reasons.append(.missingSigningIdentity)
+        }
+        if notarizationResult != .accepted {
+            reasons.append(.notarizationIncomplete)
+        }
+        if updateFeedURL == nil {
+            reasons.append(.missingUpdateFeedURL)
+        }
+        if backendVersion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            reasons.append(.missingBackendVersion)
+        }
+        if !qaSummary.isPassing {
+            reasons.append(.qaIncomplete)
+        }
+        if !strictP2PVerification.isVerified {
+            reasons.append(.strictP2PNotVerified)
+        }
+        return reasons
+    }
+}
+
+public extension JSONEncoder {
+    static var tokiDiagnostics: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+}
+
+enum PrivacyRedactor {
+    static func redactMetadata(_ metadata: [String: String]) -> [String: String] {
+        metadata.reduce(into: [:]) { output, pair in
+            guard !isSensitiveKey(pair.key) else { return }
+            output[pair.key] = redactFreeText(pair.value)
+        }
+    }
+
+    static func redactFreeText(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return trimmed }
+        let lowercased = trimmed.lowercased()
+        let sensitiveMarkers = [
+            "@",
+            "token",
+            "magic-link",
+            "candidate:",
+            "typ relay",
+            "sdp",
+            "v=0",
+            "encodedaudio",
+            "audio",
+            "replay"
+        ]
+
+        if sensitiveMarkers.contains(where: lowercased.contains) {
+            return "[redacted]"
+        }
+
+        return trimmed
+    }
+
+    private static func isSensitiveKey(_ key: String) -> Bool {
+        let lowercased = key.lowercased()
+        return [
+            "token",
+            "email",
+            "sdp",
+            "ice",
+            "candidate",
+            "audio",
+            "replay"
+        ].contains { lowercased.contains($0) }
+    }
+}

--- a/Sources/TokiCore/PermissionCoordinator.swift
+++ b/Sources/TokiCore/PermissionCoordinator.swift
@@ -6,12 +6,12 @@ import ApplicationServices
 import AVFoundation
 #endif
 
-public enum PermissionKind: Equatable, Sendable {
+public enum PermissionKind: String, Codable, Equatable, Sendable {
     case microphone
     case inputMonitoring
 }
 
-public enum PermissionStatus: Equatable, Sendable {
+public enum PermissionStatus: String, Codable, Equatable, Sendable {
     case notDetermined
     case granted
     case denied

--- a/Tests/TokiAppTests/AppShellSmokeTests.swift
+++ b/Tests/TokiAppTests/AppShellSmokeTests.swift
@@ -115,6 +115,17 @@ final class AppShellSmokeTests: XCTestCase {
         XCTAssertEqual(settingsStore.savedPreferences?.selectedInputDeviceID, "input-usb")
     }
 
+    func testReleaseMetadataIsExposedToSettings() {
+        let model = AppShellModel(
+            apiService: FakeAppShellAPIService(),
+            releaseMetadata: AppReleaseMetadata(version: "0.7.0", buildNumber: "42", updateChannel: .beta)
+        )
+
+        XCTAssertEqual(model.versionLabel, "Version 0.7.0")
+        XCTAssertEqual(model.buildLabel, "Build 42")
+        XCTAssertEqual(model.updateChannelLabel, "Beta")
+    }
+
     func testFailedConversationLoadClearsStoredSessionToken() async throws {
         let tokenStore = InMemorySessionTokenStore()
         let model = AppShellModel(

--- a/Tests/TokiCoreTests/AppSessionStateTests.swift
+++ b/Tests/TokiCoreTests/AppSessionStateTests.swift
@@ -224,4 +224,24 @@ final class AppSessionStateTests: XCTestCase {
         session.connectionChanged(.p2pUnavailable)
         XCTAssertEqual(session.activity, .p2pUnavailable)
     }
+
+    func testSessionRecordsPrivacySafeDiagnosticsForStateTransitions() {
+        let session = AppSessionState.mockSignedIn(microphone: .denied, inputMonitoring: .granted)
+
+        session.selectConversation(id: ConversationID("design"))
+        session.pushToTalkPressed(source: .mouse)
+        session.connectionChanged(.reconnecting)
+        session.connectionChanged(.p2pUnavailable)
+        session.signOut()
+
+        XCTAssertEqual(
+            session.diagnosticsEvents.map(\.category),
+            [.room, .permission, .realtime, .realtime, .auth]
+        )
+        XCTAssertEqual(
+            session.diagnosticsEvents.map(\.state),
+            ["room.join", "microphone.denied", "reconnecting", "p2p.unavailable", "signed.out"]
+        )
+        XCTAssertEqual(session.diagnosticsEvents.first?.conversationID, ConversationID("design"))
+    }
 }

--- a/Tests/TokiCoreTests/BetaReleaseDiagnosticsTests.swift
+++ b/Tests/TokiCoreTests/BetaReleaseDiagnosticsTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import TokiCore
+
+final class BetaReleaseDiagnosticsTests: XCTestCase {
+    func testDiagnosticsExportContainsMetadataOnlyAndRedactsSensitiveValues() throws {
+        let export = DiagnosticsExport(
+            release: AppReleaseMetadata(version: "0.7.0", buildNumber: "42", updateChannel: .beta),
+            macOSVersion: "15.5",
+            deviceModel: "MacBookPro18,3",
+            permissions: PermissionState(microphone: .granted, inputMonitoring: .denied),
+            selectedDevices: DiagnosticsDeviceSnapshot(inputName: "Studio Mic", outputName: "Headphones"),
+            realtimeEvents: [
+                DiagnosticsEventSummary(
+                    category: .realtime,
+                    conversationID: ConversationID("conversation-1"),
+                    peerID: nil,
+                    state: "room.join",
+                    failureReason: "token secret-token-forbidden was rejected for alice@example.com"
+                ),
+                DiagnosticsEventSummary(
+                    category: .peerConnection,
+                    conversationID: ConversationID("conversation-1"),
+                    peerID: UserID("peer-1"),
+                    state: "ice.candidate",
+                    failureReason: "candidate:842163049 1 udp 1677729535 192.0.2.5 3478 typ relay"
+                )
+            ],
+            errors: [
+                "magic link token magic-abc expired",
+                "SDP offer v=0\\no=- 46117326 2 IN IP4 127.0.0.1"
+            ]
+        )
+
+        let data = try JSONEncoder.tokiDiagnostics.encode(export.redacted())
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertTrue(text.contains("\"version\":\"0.7.0\""))
+        XCTAssertTrue(text.contains("\"updateChannel\":\"beta\""))
+        XCTAssertTrue(text.contains("Studio Mic"))
+        XCTAssertFalse(text.contains("secret-token-forbidden"))
+        XCTAssertFalse(text.contains("alice@example.com"))
+        XCTAssertFalse(text.localizedCaseInsensitiveContains("candidate:"))
+        XCTAssertFalse(text.localizedCaseInsensitiveContains("typ relay"))
+        XCTAssertFalse(text.localizedCaseInsensitiveContains("v=0"))
+        XCTAssertFalse(text.localizedCaseInsensitiveContains("magic-abc"))
+    }
+
+    func testPreBetaReleaseGateRequiresSigningNotarizationUpdatesQAAndStrictP2P() {
+        let blocked = PreBetaReleaseChecklist(
+            signingIdentity: "",
+            notarizationResult: .notRun,
+            updateFeedURL: nil,
+            backendVersion: "api-2026.07.06",
+            qaSummary: QAPassFailSummary(passed: 12, failed: 0, blocked: 0),
+            strictP2PVerification: StrictP2PReleaseVerification(
+                turnDisabled: false,
+                serverMediaDisabled: true,
+                forbiddenTermsFound: ["turn:"]
+            )
+        )
+
+        XCTAssertFalse(blocked.isReadyForBeta)
+        XCTAssertTrue(blocked.blockingReasons.contains(.missingSigningIdentity))
+        XCTAssertTrue(blocked.blockingReasons.contains(.notarizationIncomplete))
+        XCTAssertTrue(blocked.blockingReasons.contains(.missingUpdateFeedURL))
+        XCTAssertTrue(blocked.blockingReasons.contains(.strictP2PNotVerified))
+
+        let ready = PreBetaReleaseChecklist(
+            signingIdentity: "Developer ID Application: Toki",
+            notarizationResult: .accepted,
+            updateFeedURL: URL(string: "https://updates.example.com/toki/beta/appcast.xml"),
+            backendVersion: "api-2026.07.06",
+            qaSummary: QAPassFailSummary(passed: 18, failed: 0, blocked: 0),
+            strictP2PVerification: StrictP2PReleaseVerification(
+                turnDisabled: true,
+                serverMediaDisabled: true,
+                forbiddenTermsFound: []
+            )
+        )
+
+        XCTAssertTrue(ready.isReadyForBeta)
+        XCTAssertTrue(ready.blockingReasons.isEmpty)
+    }
+
+    func testPrivacySafeLogEventRedactsTokensEmailsSDPICEAndAudioPayloads() throws {
+        let event = PrivacySafeLogEvent(
+            category: .floor,
+            name: "floor.request",
+            conversationID: ConversationID("conversation-1"),
+            userID: UserID("user-1"),
+            metadata: [
+                "token": "session-token-secret",
+                "email": "alice@example.com",
+                "sdp": "v=0\\no=- 46117326 2 IN IP4 127.0.0.1",
+                "iceCandidate": "candidate:842163049 1 udp 1677729535 192.0.2.5 3478 typ relay",
+                "encodedAudio": "base64-audio",
+                "state": "requesting"
+            ]
+        )
+
+        let data = try JSONEncoder.tokiDiagnostics.encode(event.redacted())
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertTrue(text.contains("floor.request"))
+        XCTAssertTrue(text.contains("conversation-1"))
+        XCTAssertTrue(text.contains("user-1"))
+        XCTAssertTrue(text.contains("requesting"))
+        XCTAssertFalse(text.contains("session-token-secret"))
+        XCTAssertFalse(text.contains("alice@example.com"))
+        XCTAssertFalse(text.localizedCaseInsensitiveContains("candidate:"))
+        XCTAssertFalse(text.localizedCaseInsensitiveContains("encodedAudio"))
+        XCTAssertFalse(text.localizedCaseInsensitiveContains("base64-audio"))
+    }
+}

--- a/docs/release/beta-release.md
+++ b/docs/release/beta-release.md
@@ -1,0 +1,79 @@
+# Beta Release Runbook
+
+This runbook prepares direct private beta builds. It preserves the MVP rule that backend systems coordinate metadata only and never carry user audio.
+
+## Release Configuration
+
+The canonical beta release config is [`release/beta-release.json`](../../release/beta-release.json).
+
+- Signing method: Developer ID Application.
+- Update channel: `beta`.
+- Update feed: Sparkle-compatible appcast from [`release/beta-appcast.template.xml`](../../release/beta-appcast.template.xml).
+- Diagnostics: metadata-only, explicit user action, no audio, replay buffers, SDP bodies, ICE candidate bodies, auth tokens, magic-link tokens, or email addresses.
+- Media policy: STUN-only discovery, TURN disabled, server media disabled.
+
+## Local Signing And Notarization
+
+Set these values in the release shell, not in tracked files:
+
+```bash
+export TOKI_DEVELOPER_ID_APPLICATION="Developer ID Application: Example, Inc. (TEAMID)"
+export TOKI_NOTARYTOOL_PROFILE="toki-notarytool-profile"
+```
+
+Build and sign the app archive:
+
+```bash
+rtk swift build -c release
+codesign --force --deep --options runtime --timestamp --sign "$TOKI_DEVELOPER_ID_APPLICATION" .build/release/TokiApp
+ditto -c -k --keepParent .build/release/TokiApp Toki.zip
+```
+
+Submit for notarization and staple the accepted result:
+
+```bash
+xcrun notarytool submit Toki.zip --keychain-profile "$TOKI_NOTARYTOOL_PROFILE" --wait
+xcrun stapler staple .build/release/TokiApp
+spctl --assess --type execute --verbose .build/release/TokiApp
+```
+
+Record the signing identity, notarization request ID, and `spctl` result in the pre-beta checklist before marking a build ready.
+
+## Auto-Update Feed
+
+Use the appcast template to publish each beta build. Replace:
+
+- `__VERSION__` with `CFBundleShortVersionString`.
+- `__BUILD__` with `CFBundleVersion`.
+- `__SPARKLE_ED_SIGNATURE__` with the Sparkle archive signature.
+- `__ARCHIVE_BYTES__` with the uploaded archive size.
+
+Do not ship an auto-update build until a local update from version N to N+1 has been tested.
+
+## Backend Deployment Checklist
+
+- Apply `migrations/001_metadata.sql` before starting a PostgreSQL-backed beta service.
+- Set `TOKI_DATABASE_URL` for the durable database.
+- Set `TOKI_DEV_INVITES` only to the private beta allowlist.
+- Terminate TLS at the edge or run the service behind an HTTPS reverse proxy.
+- Confirm `/v1/ice-config` returns STUN URLs only and `"relayPolicy": "disabled"`.
+- Confirm `/v1/realtime` carries presence, room membership, signaling metadata, and floor-control events only.
+- Confirm structured logs include request ID, status code, event type, and available metadata IDs, with sensitive values redacted.
+
+## Diagnostics And Crash Reporting
+
+Client diagnostics exports are metadata-only and require explicit user action. They may include app version, macOS version, device model, permission states, selected device names, realtime event summaries, peer connection states, and redacted error messages.
+
+Crash reporting remains disabled for beta until the selected provider can be configured and tested to exclude audio buffers, replay data, SDP bodies, ICE candidate bodies, auth tokens, magic-link tokens, and email addresses.
+
+## Pre-Beta Gate
+
+A build is not ready until all of these are true:
+
+- Developer ID signing identity is recorded.
+- Notarization is accepted and stapled.
+- Update feed URL is recorded and version N to N+1 is tested.
+- Backend version is recorded.
+- QA matrix has no failed or blocked required cases.
+- `scripts/check-prebeta-policy.sh` passes.
+- `rtk swift test`, `rtk swift build`, and CI Go tests pass.

--- a/docs/release/qa-matrix.md
+++ b/docs/release/qa-matrix.md
@@ -1,0 +1,23 @@
+# Beta QA Matrix
+
+Run this matrix before each direct beta release. Record the tester, date, build number, backend version, result, and notes for every row.
+
+| Area | Scenario | Expected Result |
+| --- | --- | --- |
+| Install | Fresh install on a clean Mac | App launches without Gatekeeper warning after notarization. |
+| Auth | Invited email signs in | Session is created, team rooms load, and token is stored outside `UserDefaults`. |
+| Auth | Non-invited email attempts sign-in | User sees a failed sign-in state without leaking invite or token details. |
+| Permissions | Microphone denied | PTT is disabled and the user sees the microphone recovery state. |
+| Permissions | Input monitoring denied | Keyboard shortcut is disabled, manual PTT remains available. |
+| Audio devices | Selected microphone is unplugged | App falls back to the system default and shows a non-blocking warning. |
+| Audio devices | Selected output is unplugged | App falls back to the system default and shows a non-blocking warning. |
+| PTT | Two users on the same LAN complete a call | Only the active room is audible and the speaker transmits only while holding PTT. |
+| PTT | Two users press PTT at the same time | Backend grants one floor token; the other user sees floor busy. |
+| Group | 10-person room joins | Room remains capped at 10 participants and presence is visible. |
+| Reconnect | Network drops and returns | Client shows reconnecting, rejoins the active room, and renegotiates peers. |
+| Backend restart | Backend restarts during active room | Client requires room rejoin and peer renegotiation before transmitting. |
+| Restrictive network | Direct P2P cannot be established | User sees direct P2P unavailable and Toki does not transmit. |
+| Replay | Local replay after received audio | Replay plays only locally received active-room audio and clears on room switch/sign-out. |
+| Diagnostics | User exports diagnostics | Export contains metadata only and no raw audio, replay data, SDP, ICE candidate bodies, tokens, or emails. |
+| Update | Version N updates to N+1 | Sparkle-compatible beta feed updates the app and preserves settings. |
+| Release gate | Pre-beta policy check runs | No TURN, SFU, MCU, media upload, or server media path is present. |

--- a/internal/httpapi/logging.go
+++ b/internal/httpapi/logging.go
@@ -1,0 +1,111 @@
+package httpapi
+
+import (
+	"bufio"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+)
+
+type PrivacySafeLogFields struct {
+	StatusCode     int
+	UserID         string
+	TeamID         string
+	ConversationID string
+	EventType      string
+	FailureReason  string
+}
+
+type PrivacySafeLogger struct {
+	logger *slog.Logger
+}
+
+func NewPrivacySafeLogger(handler slog.Handler) *PrivacySafeLogger {
+	return &PrivacySafeLogger{logger: slog.New(handler)}
+}
+
+func (l *PrivacySafeLogger) RequestCompleted(r *http.Request, fields PrivacySafeLogFields) {
+	if l == nil || l.logger == nil {
+		return
+	}
+
+	attrs := []any{
+		"request_id", requestID(r),
+		"method", r.Method,
+		"path", r.URL.Path,
+		"status_code", fields.StatusCode,
+		"event_type", redactedText(fields.EventType),
+	}
+	if fields.UserID != "" {
+		attrs = append(attrs, "user_id", fields.UserID)
+	}
+	if fields.TeamID != "" {
+		attrs = append(attrs, "team_id", fields.TeamID)
+	}
+	if fields.ConversationID != "" {
+		attrs = append(attrs, "conversation_id", fields.ConversationID)
+	}
+	if fields.FailureReason != "" {
+		attrs = append(attrs, "failure_reason", redactedText(fields.FailureReason))
+	}
+
+	l.logger.InfoContext(r.Context(), "request completed", attrs...)
+}
+
+func requestID(r *http.Request) string {
+	if value := strings.TrimSpace(r.Header.Get("X-Request-ID")); value != "" {
+		return redactedText(value)
+	}
+	return "missing"
+}
+
+func redactedText(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return trimmed
+	}
+	lower := strings.ToLower(trimmed)
+	for _, marker := range []string{
+		"@",
+		"token",
+		"magic-link",
+		"candidate:",
+		"typ relay",
+		"sdp",
+		"v=0",
+		"audio",
+		"replay",
+	} {
+		if strings.Contains(lower, marker) {
+			return "[redacted]"
+		}
+	}
+	return trimmed
+}
+
+type statusRecordingResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (w *statusRecordingResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *statusRecordingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, http.ErrNotSupported
+	}
+	w.statusCode = http.StatusSwitchingProtocols
+	return hijacker.Hijack()
+}
+
+func (w *statusRecordingResponseWriter) Flush() {
+	flusher, ok := w.ResponseWriter.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}

--- a/internal/httpapi/logging_test.go
+++ b/internal/httpapi/logging_test.go
@@ -1,0 +1,54 @@
+package httpapi
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPrivacySafeLoggerRedactsSensitiveRequestContext(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewPrivacySafeLogger(slog.NewJSONHandler(&buf, nil))
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/session", strings.NewReader(`{"token":"magic-secret","email":"alice@example.com","sdp":"v=0","iceCandidate":"candidate:1 typ relay","audio":"base64-audio"}`))
+	req.Header.Set("Authorization", "Bearer session-secret")
+	req.Header.Set("X-Request-ID", "request-1")
+
+	logger.RequestCompleted(req, PrivacySafeLogFields{
+		StatusCode:     http.StatusCreated,
+		UserID:         "user-1",
+		TeamID:         "team-1",
+		ConversationID: "conversation-1",
+		EventType:      "auth.session",
+		FailureReason:  "token magic-secret belongs to alice@example.com",
+	})
+
+	output := buf.String()
+	for _, forbidden := range []string{
+		"session-secret",
+		"magic-secret",
+		"alice@example.com",
+		"candidate:1",
+		"typ relay",
+		"base64-audio",
+		"v=0",
+	} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("log output contains sensitive value %q: %s", forbidden, output)
+		}
+	}
+	for _, required := range []string{
+		"request-1",
+		"user-1",
+		"team-1",
+		"conversation-1",
+		"auth.session",
+		"201",
+	} {
+		if !strings.Contains(output, required) {
+			t.Fatalf("log output missing %q: %s", required, output)
+		}
+	}
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -14,6 +15,7 @@ type Server struct {
 	store    store.Store
 	realtime *realtime.Hub
 	mux      *http.ServeMux
+	logger   *PrivacySafeLogger
 }
 
 type userResponse struct {
@@ -66,13 +68,23 @@ type conversationResponse struct {
 }
 
 func NewServer(st store.Store) http.Handler {
-	s := &Server{store: st, realtime: realtime.NewHub(st, nil), mux: http.NewServeMux()}
+	s := &Server{
+		store:    st,
+		realtime: realtime.NewHub(st, nil),
+		mux:      http.NewServeMux(),
+		logger:   NewPrivacySafeLogger(slogDefaultHandler()),
+	}
 	s.routes()
 	return s
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.mux.ServeHTTP(w, r)
+	recorder := &statusRecordingResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	s.mux.ServeHTTP(recorder, r)
+	s.logger.RequestCompleted(r, PrivacySafeLogFields{
+		StatusCode: recorder.statusCode,
+		EventType:  eventTypeForRequest(r),
+	})
 }
 
 func (s *Server) routes() {
@@ -363,4 +375,31 @@ func displayNameFromEmail(email string) string {
 		return "Toki User"
 	}
 	return name
+}
+
+func eventTypeForRequest(r *http.Request) string {
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/v1/auth/magic-link":
+		return "auth.magic_link"
+	case r.Method == http.MethodPost && r.URL.Path == "/v1/auth/session":
+		return "auth.session"
+	case r.Method == http.MethodGet && r.URL.Path == "/v1/me":
+		return "auth.me"
+	case r.Method == http.MethodGet && r.URL.Path == "/v1/ice-config":
+		return "media.ice_config"
+	case r.Method == http.MethodGet && r.URL.Path == "/v1/realtime":
+		return "realtime.websocket"
+	case r.Method == http.MethodGet && r.URL.Path == "/v1/conversations":
+		return "conversation.list"
+	case r.Method == http.MethodPost && r.URL.Path == "/v1/conversations":
+		return "conversation.create"
+	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/conversations/"):
+		return "conversation.members"
+	default:
+		return "request"
+	}
+}
+
+func slogDefaultHandler() slog.Handler {
+	return slog.Default().Handler()
 }

--- a/plans/07-beta-release-observability-and-qa.md
+++ b/plans/07-beta-release-observability-and-qa.md
@@ -29,17 +29,17 @@
 
 ## Implementation Steps
 
-- [ ] Create release configuration for Developer ID signing.
-- [ ] Add notarization workflow documentation and local verification commands.
-- [ ] Add auto-update feed configuration for beta builds.
-- [ ] Add app version, build number, and update channel display in settings.
-- [ ] Add structured client logs for state transitions: auth, realtime, room join, floor, peer connection, permission, and device fallback.
-- [ ] Redact or omit sensitive fields from logs: tokens, emails where unnecessary, SDP bodies, ICE candidates, audio data, and replay buffers.
-- [ ] Add backend structured logs for request IDs, user IDs, team IDs, conversation IDs, event types, and failure reasons.
-- [ ] Add a diagnostics export that includes metadata only and requires explicit user action.
-- [ ] Add crash reporting only if it can be configured to exclude audio buffers and sensitive payloads.
-- [ ] Build a QA matrix covering fresh install, permissions denied, two-user LAN call, 10-person room, simultaneous PTT, reconnect, backend restart, device unplug, and restrictive network failure.
-- [ ] Add a final pre-beta checklist requiring explicit confirmation that TURN and server media are disabled.
+- [x] Create release configuration for Developer ID signing.
+- [x] Add notarization workflow documentation and local verification commands.
+- [x] Add auto-update feed configuration for beta builds.
+- [x] Add app version, build number, and update channel display in settings.
+- [x] Add structured client logs for state transitions: auth, realtime, room join, floor, peer connection, permission, and device fallback.
+- [x] Redact or omit sensitive fields from logs: tokens, emails where unnecessary, SDP bodies, ICE candidates, audio data, and replay buffers.
+- [x] Add backend structured logs for request IDs, user IDs, team IDs, conversation IDs, event types, and failure reasons.
+- [x] Add a diagnostics export that includes metadata only and requires explicit user action.
+- [x] Add crash reporting only if it can be configured to exclude audio buffers and sensitive payloads. Crash reporting remains disabled until a provider is selected and verified against the privacy exclusions.
+- [x] Build a QA matrix covering fresh install, permissions denied, two-user LAN call, 10-person room, simultaneous PTT, reconnect, backend restart, device unplug, and restrictive network failure.
+- [x] Add a final pre-beta checklist requiring explicit confirmation that TURN and server media are disabled.
 
 ## Interfaces
 

--- a/release/beta-appcast.template.xml
+++ b/release/beta-appcast.template.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Toki Beta Updates</title>
+    <link>https://updates.example.com/toki/beta/appcast.xml</link>
+    <description>Private beta update feed for direct-distributed Toki builds.</description>
+    <item>
+      <title>Toki __VERSION__ (__BUILD__)</title>
+      <sparkle:version>__BUILD__</sparkle:version>
+      <sparkle:shortVersionString>__VERSION__</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url="https://updates.example.com/toki/beta/Toki-__VERSION__.zip"
+        sparkle:edSignature="__SPARKLE_ED_SIGNATURE__"
+        length="__ARCHIVE_BYTES__"
+        type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>

--- a/release/beta-release.json
+++ b/release/beta-release.json
@@ -1,0 +1,32 @@
+{
+  "channel": "beta",
+  "bundleIdentifier": "com.toki.app",
+  "signing": {
+    "method": "developer-id",
+    "identityEnvironmentVariable": "TOKI_DEVELOPER_ID_APPLICATION",
+    "notarizationProfileEnvironmentVariable": "TOKI_NOTARYTOOL_PROFILE"
+  },
+  "autoUpdate": {
+    "provider": "sparkle-compatible-appcast",
+    "feedURL": "https://updates.example.com/toki/beta/appcast.xml",
+    "minimumSystemVersion": "14.0"
+  },
+  "diagnostics": {
+    "metadataOnly": true,
+    "requiresExplicitUserAction": true,
+    "excludedPayloads": [
+      "raw-audio",
+      "local-replay-audio",
+      "sdp-bodies",
+      "ice-candidate-bodies",
+      "auth-tokens",
+      "magic-link-tokens",
+      "email-addresses"
+    ]
+  },
+  "mediaPolicy": {
+    "stunOnly": true,
+    "turnDisabled": true,
+    "serverMediaDisabled": true
+  }
+}

--- a/scripts/check-prebeta-policy.sh
+++ b/scripts/check-prebeta-policy.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'pre-beta policy check failed: %s\n' "$1" >&2
+  exit 1
+}
+
+check_absent() {
+  local pattern="$1"
+  shift
+  if grep -RInE "$pattern" "$@" >/tmp/toki-prebeta-policy-hit.txt; then
+    cat /tmp/toki-prebeta-policy-hit.txt >&2
+    fail "forbidden runtime media pattern matched: $pattern"
+  fi
+}
+
+check_absent 'turns?://' cmd internal Sources/TokiApp
+check_absent 'turns?://' Sources/TokiCore --exclude='ICEConfig.swift' --exclude='BetaReleaseDiagnostics.swift'
+check_absent '(^|[^A-Za-z])(SFU|MCU)([^A-Za-z]|$)' cmd internal Sources/TokiApp Sources/TokiCore
+check_absent 'media[-_ ]?upload|audio[-_ ]?upload|server[-_ ]?media|raw[-_ ]?audio[-_ ]?upload' cmd internal Sources/TokiApp Sources/TokiCore
+
+grep -q 'RelayPolicy: "disabled"' internal/httpapi/server.go || fail 'backend ICE config must return relayPolicy disabled'
+grep -q 'relayPolicy == \.disabled' Sources/TokiCore/ICEConfig.swift || fail 'client strict ICE validation must require disabled relay policy'
+grep -q '"turnDisabled": true' release/beta-release.json || fail 'release config must keep TURN disabled'
+grep -q '"serverMediaDisabled": true' release/beta-release.json || fail 'release config must keep server media disabled'
+
+printf 'pre-beta policy check passed\n'


### PR DESCRIPTION
## Summary

- Add beta release readiness artifacts for Developer ID signing, notarization, beta appcast configuration, backend deployment, QA, and pre-beta strict P2P policy checks.
- Add privacy-safe diagnostics/release models, app Settings version/build/channel display, and bounded client diagnostics transition events.
- Add backend structured request logging helpers with redaction for tokens, emails, SDP, ICE candidates, audio, and replay terms.
- Extend CI with a pre-beta policy job that verifies strict P2P and privacy-sensitive release defaults.

## Validation

- `rtk swift test` passed: 56 XCTest tests, 0 failures.
- `rtk swift build` passed.
- `rtk scripts/check-prebeta-policy.sh` passed.
- `rtk git diff --cached --check` passed before commit.
- `rtk go test ./...` could not run locally because `rtk` cannot spawn `go` in this environment; the existing CI Go Backend job covers the new backend test.